### PR TITLE
Phase 1: Quick-Fixes (isolierte Bugs, je 1 Commit)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npx ng *)",
+      "Bash(gh auth *)",
+      "PowerShell(gh --version)",
+      "Bash(git checkout *)",
+      "Bash(git add *)",
+      "Bash(git commit -m 'docs: add refactoring roadmap with smoke-test checklist \\(phase 0\\) *)",
+      "Bash(git commit -m 'fix: guard against null currentChannel in add-member template *)",
+      "Bash(git commit -m 'fix: remove erroneous @Injectable decorator from NewmessageComponent *)",
+      "Bash(git commit -m 'fix: actually invoke resetList\\(\\) in searchWithTag default case *)"
+    ]
+  }
+}

--- a/REFACTORING.md
+++ b/REFACTORING.md
@@ -12,7 +12,7 @@ Diese Roadmap ist die Arbeitsgrundlage für die kommenden Refactoring-Sessions. 
    - No-op-Stubs in `src/app/shared/services/navigation/navigation.service.ts`: `setUrl()` loggt nur `'test'` (Z.121), `goToThread()` loggt nur die ID (Z.51), `showChannel()`/`toggleThread()` leer (Z.125–127) → **Thread- und Mention-Navigation sind faktisch funktionslos**
    - `chat-new.component.ts` Z.13–16: Komponente hat `@Injectable({providedIn:'root'})` **und** `@Component` — Bug
    - `search.service.ts` Z.190: `this.resetList;` ohne `()` — wird nie ausgeführt
-   - Feld-Mismatch: Queries auf `fullname`/`user.key`, obwohl das User-Model `displayName`/`id` hat (message-template Z.225–227, 268, 326, 341 + chat-thread) → Reaktionsnamen bleiben leer, Mention-Lookup defekt
+   - Feld-Mismatch: Queries auf `displayName`/`user.key`, obwohl das User-Model `displayName`/`id` hat (message-template Z.225–227, 268, 326, 341 + chat-thread) → Reaktionsnamen bleiben leer, Mention-Lookup defekt
 2. **Memory Leaks**
    - `route.queryParams.subscribe` ohne Cleanup (chat-thread Z.63), `route.paramMap.subscribe` (chat-direct Z.56)
    - `onSnapshot` in chat-thread Z.125 wird nie dem deklarierten `unsubMessages` zugewiesen
@@ -41,7 +41,7 @@ Diese Roadmap ist die Arbeitsgrundlage für die kommenden Refactoring-Sessions. 
 0. **Build-Fehler fixen (blockiert alles):** `add-member.component.html` Z.39 — `channelService.currentChannel().name` schlägt fehl, weil `currentChannel()` `null` sein kann. Fix: `currentChannel()?.name` oder `@if`-Guard
 1. `@Injectable`-Decorator aus `src/app/features/app_chat/components/chat-new-message/chat-new.component.ts` (Z.13–15) entfernen
 2. `this.resetList;` → `this.resetList();` in `search.service.ts` Z.190
-3. Feld-Mismatch `fullname`/`key` → `displayName`/`id` in message-template + chat-thread (vorher per Grep prüfen, ob Firestore-Dokumente noch `fullname` enthalten — das User-Model ist die Wahrheit)
+3. Feld-Mismatch `displayName`/`key` → `displayName`/`id` in message-template + chat-thread (vorher per Grep prüfen, ob Firestore-Dokumente noch `displayName` enthalten — das User-Model ist die Wahrheit)
 4. Toten `getThread()`-Listener in `chat-channel.component.ts` Z.133–144 samt Aufrufer löschen
 5. Hartcodierte E-Mail in `messages.service.ts` Z.14 entfernen; `console.log` in fire-service Z.63 und navigation.service Z.106 entfernen
 6. Leeren Stub `UserService.showFeedback()` klären: delegieren oder Aufrufer entfernen
@@ -136,17 +136,17 @@ Reine Moves/Renames erzeugen riesige Diffs und würden die Reviews der inhaltlic
 
 ## Reihenfolge-Begründung
 
-| Phase | Warum an dieser Stelle |
-|---|---|
-| 0 | Ohne Baseline keine Regression erkennbar (keine Tests vorhanden) |
-| 1 | Isolierte Bugs zuerst: billig, risikoarm, entstören alle späteren Tests |
-| 2 | Branch-Zweck abschließen, bevor Neues beginnt; funktionierende Navigation ist Voraussetzung, um alles Weitere manuell testen zu können |
-| 3 | Leaks vor State-Refactor, sonst Geisterdaten-Debugging in Phase 4 |
-| 4 | Fundament (eine Channel-Wahrheit, kein DI-Zyklus) muss stehen, bevor Datenzugriffe verschoben werden |
-| 5 | Firestore aus den Komponenten ziehen macht Phase 6/7 erst möglich |
-| 6 | Dedup vor Zerlegung: sonst wird Dupliziertes mit-zerlegt |
-| 7 | Komponenten-Split/OnPush zuletzt der inhaltlichen Phasen — höchstes Regressionsrisiko, profitiert von allem davor |
-| 8 | Reine Moves ganz am Ende, um die Diffs der inhaltlichen Phasen sauber zu halten |
+| Phase | Warum an dieser Stelle                                                                                                                 |
+| ----- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| 0     | Ohne Baseline keine Regression erkennbar (keine Tests vorhanden)                                                                       |
+| 1     | Isolierte Bugs zuerst: billig, risikoarm, entstören alle späteren Tests                                                                |
+| 2     | Branch-Zweck abschließen, bevor Neues beginnt; funktionierende Navigation ist Voraussetzung, um alles Weitere manuell testen zu können |
+| 3     | Leaks vor State-Refactor, sonst Geisterdaten-Debugging in Phase 4                                                                      |
+| 4     | Fundament (eine Channel-Wahrheit, kein DI-Zyklus) muss stehen, bevor Datenzugriffe verschoben werden                                   |
+| 5     | Firestore aus den Komponenten ziehen macht Phase 6/7 erst möglich                                                                      |
+| 6     | Dedup vor Zerlegung: sonst wird Dupliziertes mit-zerlegt                                                                               |
+| 7     | Komponenten-Split/OnPush zuletzt der inhaltlichen Phasen — höchstes Regressionsrisiko, profitiert von allem davor                      |
+| 8     | Reine Moves ganz am Ende, um die Diffs der inhaltlichen Phasen sauber zu halten                                                        |
 
 ---
 
@@ -177,7 +177,7 @@ Nach jeder Phase (mindestens nach jedem Merge) einmal komplett durchspielen — 
 
 - Thread-Navigation über `goToThread()` ist funktionslos (No-op-Stub)
 - Channel-Mention-Navigation über `setUrl()`/`showChannel()` ist funktionslos (No-op-Stubs)
-- Reaktions-Hover zeigt vermutlich keine Namen (Feld-Mismatch `fullname`/`key` vs. `displayName`/`id`)
+- Reaktions-Hover zeigt vermutlich keine Namen (Feld-Mismatch `displayName`/`key` vs. `displayName`/`id`)
 
 ---
 

--- a/REFACTORING.md
+++ b/REFACTORING.md
@@ -1,0 +1,187 @@
+# Refactoring-Roadmap DA-Bubble
+
+Stand: 2026-07-12 · Branch: `refactor-chat-navigation` (16 Commits vor `main`)
+
+Diese Roadmap ist die Arbeitsgrundlage für die kommenden Refactoring-Sessions. Jede Phase ist einzeln committbar und über die Smoke-Test-Checkliste (unten) manuell verifizierbar — es gibt kein Test-Sicherheitsnetz (alle `.spec.ts` sind ungepflegte CLI-Scaffolds).
+
+---
+
+## Kern-Befunde der Analyse
+
+1. **Kaputte Funktionalität durch unfertigen Refactor**
+   - No-op-Stubs in `src/app/shared/services/navigation/navigation.service.ts`: `setUrl()` loggt nur `'test'` (Z.121), `goToThread()` loggt nur die ID (Z.51), `showChannel()`/`toggleThread()` leer (Z.125–127) → **Thread- und Mention-Navigation sind faktisch funktionslos**
+   - `chat-new.component.ts` Z.13–16: Komponente hat `@Injectable({providedIn:'root'})` **und** `@Component` — Bug
+   - `search.service.ts` Z.190: `this.resetList;` ohne `()` — wird nie ausgeführt
+   - Feld-Mismatch: Queries auf `fullname`/`user.key`, obwohl das User-Model `displayName`/`id` hat (message-template Z.225–227, 268, 326, 341 + chat-thread) → Reaktionsnamen bleiben leer, Mention-Lookup defekt
+2. **Memory Leaks**
+   - `route.queryParams.subscribe` ohne Cleanup (chat-thread Z.63), `route.paramMap.subscribe` (chat-direct Z.56)
+   - `onSnapshot` in chat-thread Z.125 wird nie dem deklarierten `unsubMessages` zugewiesen
+   - auth.service Z.220/226: `onAuthStateChanged` + verschachteltes `onSnapshot` werden nie abgemeldet (Re-Subscribe-Leak bei jedem Auth-Wechsel)
+   - chat-channel Z.133–144: `getThread()` erstellt Listener mit komplett auskommentiertem Callback, wird nie abgemeldet
+3. **Mehrere Sources of Truth für den aktiven Channel**: Route-Param vs. `ChannelService.currentChannel` vs. lokales `onSnapshot` in `chat-channel.component.ts` Z.116
+4. **Layering gebrochen**: direkte Firestore-Zugriffe (`inject(Firestore)`, `query`, `onSnapshot`) in message-template, chat-thread und chat-channel statt über den FireService; Zirkularität FireService↔AuthService via `Injector.get()` (fire-service Z.72)
+5. **Duplizierung**: Mention-Handling (`onMentionClick`/`showProfileOrChannel`/`caseUser`/`caseChannel`) wortgleich in message-template Z.285–346 und chat-thread Z.147–208; Magic String `DEFAULT_CHANNEL_ID = 'KqvcY68R1jP2UsQkv6Nz'` doppelt (auth.service Z.111, fire-service Z.75); doppelte avatar-selection-Komponente (app_auth + dialogs)
+6. **Qualität**: 83× `any` in 25 Dateien (Hotspots: message-template 16×, fire-service 8×, search.service 7×); nirgends `OnPush` trotz Signals; Mix aus `@Input()` und `input()`; `console.log` bei jedem User-Snapshot (fire-service Z.63); README = CLI-Default
+
+---
+
+## Phase 0 — Baseline
+
+**Ziel:** Referenzzustand festhalten, gegen den jede Phase verglichen wird.
+
+- [x] `ng build` ausführen → Ergebnis siehe [Baseline-Status](#baseline-status)
+- [ ] Smoke-Test-Checkliste (unten) einmal komplett durchspielen und den **Ist-Zustand notieren** — was jetzt schon kaputt ist (z. B. Thread-Öffnen, Mention-Klick), darf später nicht dem Refactor zugeschrieben werden
+
+**Risiko:** keins (kein Code-Change).
+
+## Phase 1 — Quick-Fixes (isolierte Bugs, je 1 Commit)
+
+**Ziel:** Punktuelle, unabhängige Fehler beseitigen, bevor am Fundament gearbeitet wird.
+
+0. **Build-Fehler fixen (blockiert alles):** `add-member.component.html` Z.39 — `channelService.currentChannel().name` schlägt fehl, weil `currentChannel()` `null` sein kann. Fix: `currentChannel()?.name` oder `@if`-Guard
+1. `@Injectable`-Decorator aus `src/app/features/app_chat/components/chat-new-message/chat-new.component.ts` (Z.13–15) entfernen
+2. `this.resetList;` → `this.resetList();` in `search.service.ts` Z.190
+3. Feld-Mismatch `fullname`/`key` → `displayName`/`id` in message-template + chat-thread (vorher per Grep prüfen, ob Firestore-Dokumente noch `fullname` enthalten — das User-Model ist die Wahrheit)
+4. Toten `getThread()`-Listener in `chat-channel.component.ts` Z.133–144 samt Aufrufer löschen
+5. Hartcodierte E-Mail in `messages.service.ts` Z.14 entfernen; `console.log` in fire-service Z.63 und navigation.service Z.106 entfernen
+6. Leeren Stub `UserService.showFeedback()` klären: delegieren oder Aufrufer entfernen
+
+**Risiko:** niedrig. **Verifikation:** nach jedem Commit `ng build`; nach Fix 3: Reaktion setzen → Hover zeigt Namen; Mention klicken → Profil öffnet.
+
+## Phase 2 — Chat-Navigation-Refactor abschließen (Zweck dieses Branches)
+
+**Ziel:** No-op-Stubs im NavigationService durch echte Implementierungen ersetzen → Thread- und Mention-Navigation funktionieren wieder → Branch ist mergefähig.
+
+- `navigation.service.ts`:
+  - Signal `isThreadOpen = signal(false)` einführen
+  - `goToThread(messageId)` → `router.navigate([], { queryParams: {...}, queryParamsHandling: 'merge' })` + `isThreadOpen.set(true)`
+  - `toggleThread('close')` → Signal zurücksetzen + `messageId`-QueryParam entfernen
+  - `setUrl(type, id)` typisieren (`'channel' | 'direct'`) und auf `selectChannel`/`selectDirectMessageRecipient` delegieren — oder Aufrufer direkt umstellen und `setUrl` löschen
+  - `showChannel()` implementieren (Mobile: Thread-Drawer schließen) oder löschen
+- `main-chat.component.html` Z.26: `mat-drawer` an `isThreadOpen` binden (via Effect, da MatDrawer imperativ ist)
+- Aufrufer anpassen: `message-template.component.ts` Z.129, 344–345; `chat-thread.component.ts` Z.136, 206–207; `search-result.component.ts` Z.69–70
+
+**Risiko:** mittel (QueryParam-/Drawer-Timing). **Verifikation:** Thread öffnen → antworten → schließen; Channel wechseln bei offenem Thread; `#channel`- und `@user`-Mention klicken; Suchergebnis klicken — **Desktop UND Mobile (<1024px)**.
+
+➡️ **Danach: Branch in `main` mergen. Alle Folgephasen auf neuen Branches.**
+
+## Phase 3 — Memory Leaks & Subscription-Hygiene
+
+**Ziel:** Alle Subscriptions und Firestore-Listener deterministisch aufräumen — muss VOR dem State-Refactor passieren, sonst debuggt man in Phase 4 Geisterdaten verwaister Listener.
+
+- `takeUntilDestroyed` für `route.queryParams` (chat-thread Z.63) und `route.paramMap` (chat-direct Z.56)
+- chat-thread: `onSnapshot`-Rückgabe dem deklarierten `unsubMessages` zuweisen; alten Listener vor jedem Re-Subscribe abmelden (Muster wie `chat-channel.component.ts` Z.117)
+- auth.service: verschachteltes `onSnapshot` vor jedem Neu-Abonnieren abmelden (Re-Subscribe-Leak bei Logout→Login)
+- channel.service: verlorenes Unsubscribe von `fireService.subAllUsers()` im Konstruktor aufheben; prüfen, ob FireService denselben Listener schon hält
+- Projektweiter Grep-Sweep: jedes `subscribe(` / `onSnapshot(` auf besitzenden Unsub prüfen
+
+**Risiko:** niedrig–mittel. **Verifikation:** 10× Channel-Wechsel, Thread mehrfach öffnen/schließen, Logout/Login → gesendete Nachricht erscheint genau 1× (doppeltes Rendern = verwaister Listener).
+
+## Phase 4 — Single Source of Truth „aktiver Channel" + DI-Zyklus auflösen
+
+**Ziel:** Genau eine Wahrheit für den aktiven Channel: der Route-Param. Services leiten ab, Komponenten konsumieren nur.
+**Invasivster Schritt der Roadmap — strikt in Reihenfolge 1→4, je 1 Commit + Smoke-Test.**
+
+1. `DEFAULT_CHANNEL_ID` nach `src/app/shared/constants.ts` (neu) extrahieren (auth.service Z.111, fire-service Z.75)
+2. `ChannelService.setActiveChannel(id)`: der Service hält das EINE `onSnapshot` aufs Channel-Dokument und exponiert `currentChannel` als Signal; das komponenten-eigene Snapshot in `chat-channel.component.ts` Z.116–127 entfällt
+3. Alle `currentChannel`-Leser (chat-header, edit.channel, add-member, textarea) per Grep finden und auf das Service-Signal umstellen
+4. Zyklus FireService↔AuthService auflösen: User-Persistenz aus AuthService in neuen `UserStore` ziehen, von dem beide abhängen; `Injector.get(AuthService)` in fire-service Z.72 entfällt
+
+**Risiko:** hoch. **Verifikation:** Channel-Wechsel → Header/Nachrichtenliste/Edit-Dialog/Member-Liste zeigen konsistent denselben Channel; Channel-Name im Edit-Dialog ändern → Header aktualisiert live; Deep-Link-Reload auf `/main/channel/:id`.
+
+## Phase 5 — Firestore raus aus den Komponenten
+
+**Ziel:** Komponenten sprechen nur noch mit Services; `inject(Firestore)`, `query`, `onSnapshot` verschwinden aus der Komponentenschicht.
+
+- `findUserByDisplayName(name)` / `findChannelByName(name)` in UserStore bzw. ChannelService (ersetzt die query/where-Duplikate in message-template Z.266–346, chat-thread Z.80–207)
+- Thread-Datenzugriff in MessagesService: `subscribeThread(channelId, messageId)`, `getParentMessage(...)` → Firestore-Inject in chat-thread entfällt
+- Reactions-Zugriffe (message-template Z.34, 266–275) in MessagesService oder neuen ReactionsService
+- FireService intern in `UsersApi`/`ChannelsApi`/`MessagesApi` gliedern (Fassade behalten, kein Big Bang); `myChannels`-Guest-Logik in ChannelService
+
+**Risiko:** mittel (viele Aufrufstellen, aber reine Verschiebung). **Verifikation:** kompletter Smoke-Test; gezielt: Mention auf User UND Channel, Reaktion hinzufügen/entfernen, Thread mit >2 Antworten.
+
+## Phase 6 — Duplizierung entfernen & Service-SRP
+
+**Ziel:** Jede Logik existiert genau einmal.
+
+- `MentionService` extrahieren (`src/app/shared/services/mention/`): wortgleicher Code aus message-template + chat-thread; nach Phase 5 nur noch Dispatch-Logik
+- Doppelte avatar-selection konsolidieren: `app_auth/components/avatar-selection` (geroutet) vs. `dialogs/avatar-selection/avatar-selection` (nur von user-profile genutzt) → eine Komponente mit Kontext-Input
+- AuthService-SRP: FormBuilder-Factories (`createLoginForm`, `createRegisterForm`) in die Auth-Komponenten verschieben
+- SearchService trennen: UI-State (welche Liste offen) von der Suchlogik
+
+**Risiko:** niedrig–mittel. **Verifikation:** Mentions in Channel-Nachricht UND Thread-Antwort; Avatar-Auswahl bei Registrierung und im Profil; Login/Registrierung/Passwort-Reset; Suche öffnen/schließen.
+
+## Phase 7 — Komponenten zerlegen & Typisierung
+
+**Ziel:** message-template (347 Z., 16× `any`) & Co. unter die Projektlimits bringen; `any` eliminieren; einheitliche Reaktivität.
+
+- message-template aufteilen: `message-reactions.component`, `message-edit.component`, schlanker Parent
+- Message-Typ-Diskriminierung vereinheitlichen: `instanceof ChannelMessage` ODER Discriminator-Feld im Model — nicht beide Muster (`'reaction' in data` vs. `instanceof`) parallel
+- `any`-Abbau nach Hotspots (message-template 16×, fire-service 8×, search.service 7×); Models aus `app_chat/models` und `app_auth/models/user` konsequent als Typen verwenden
+- Danach: `@Input()` → `input()`, `ChangeDetectionStrategy.OnPush` — als letzter, eigener Commit pro Komponentengruppe (deckt Zone-Abhängigkeiten auf)
+
+**Risiko:** mittel. **Verifikation:** voller Smoke-Test; Live-Updates mit zweitem Browserfenster (neue Nachricht, Reaktion, Edit eines zweiten Users).
+
+## Phase 8 — Struktur, Naming, Doku (bewusst zuletzt)
+
+Reine Moves/Renames erzeugen riesige Diffs und würden die Reviews der inhaltlichen Phasen verschmutzen.
+
+- Renames: `edit.channel` → `edit-channel`; `reciver`/`reciever` → `receiver` (inkl. Query-Params aus Phase 2 synchron umbenennen!); `app_auth`/`app_chat`/`app_channel` → `auth`/`chat`/`channel` (ein Commit, `git mv` + Import-Fixes)
+- `features/pipes` → `shared/pipes`; `features/dialogs` auflösen (user-profile/user-menu/dialog-reciver zu ihren Features)
+- README ersetzen (Projektbeschreibung, Setup, Firebase-Hinweis); tote `.spec.ts`-Scaffolds löschen oder mit minimalen Smoke-Tests füllen
+
+**Risiko:** niedrig (Compiler fängt Importe; SCSS-Pfade und `templateUrl`s manuell prüfen). **Verifikation:** `ng build` + einmal kompletter Smoke-Test.
+
+---
+
+## Reihenfolge-Begründung
+
+| Phase | Warum an dieser Stelle |
+|---|---|
+| 0 | Ohne Baseline keine Regression erkennbar (keine Tests vorhanden) |
+| 1 | Isolierte Bugs zuerst: billig, risikoarm, entstören alle späteren Tests |
+| 2 | Branch-Zweck abschließen, bevor Neues beginnt; funktionierende Navigation ist Voraussetzung, um alles Weitere manuell testen zu können |
+| 3 | Leaks vor State-Refactor, sonst Geisterdaten-Debugging in Phase 4 |
+| 4 | Fundament (eine Channel-Wahrheit, kein DI-Zyklus) muss stehen, bevor Datenzugriffe verschoben werden |
+| 5 | Firestore aus den Komponenten ziehen macht Phase 6/7 erst möglich |
+| 6 | Dedup vor Zerlegung: sonst wird Dupliziertes mit-zerlegt |
+| 7 | Komponenten-Split/OnPush zuletzt der inhaltlichen Phasen — höchstes Regressionsrisiko, profitiert von allem davor |
+| 8 | Reine Moves ganz am Ende, um die Diffs der inhaltlichen Phasen sauber zu halten |
+
+---
+
+## Smoke-Test-Checkliste
+
+Nach jeder Phase (mindestens nach jedem Merge) einmal komplett durchspielen — Desktop **und** Mobile-Viewport (<1024px):
+
+- [ ] Login mit E-Mail/Passwort; Login als Gast; Google-Login
+- [ ] Registrierung inkl. Avatar-Auswahl
+- [ ] Channel in der Sidebar öffnen → Nachrichten laden
+- [ ] Nachricht senden → erscheint genau 1×
+- [ ] Nachricht bearbeiten
+- [ ] Reaktion (Emoji) hinzufügen → Hover zeigt Namen der Reagierenden; Reaktion wieder entfernen
+- [ ] Thread öffnen („Antworten") → Parent-Nachricht korrekt; Antwort senden; Thread schließen
+- [ ] Channel wechseln bei offenem Thread → kein veralteter Thread-Inhalt
+- [ ] `@user`-Mention klicken → Profil-Dialog öffnet
+- [ ] `#channel`-Mention klicken → Navigation zum Channel
+- [ ] Suche (Header): User/Channel suchen und Ergebnis anklicken → Navigation
+- [ ] Direct Message öffnen, Nachricht senden; Profil des Empfängers öffnen
+- [ ] Neuer Chat („Neue Nachricht"): Empfänger via Suche wählen, senden
+- [ ] Channel bearbeiten: Name/Beschreibung ändern → Header aktualisiert live
+- [ ] Member zum Channel hinzufügen
+- [ ] Channel erstellen
+- [ ] Deep-Link: Browser-Reload direkt auf `/main/channel/:id`
+- [ ] Logout → Login-Seite; erneuter Login funktioniert
+
+### Bekannte Defekte VOR dem Refactoring (Ist-Zustand, nicht dem Refactor zuschreiben)
+
+- Thread-Navigation über `goToThread()` ist funktionslos (No-op-Stub)
+- Channel-Mention-Navigation über `setUrl()`/`showChannel()` ist funktionslos (No-op-Stubs)
+- Reaktions-Hover zeigt vermutlich keine Namen (Feld-Mismatch `fullname`/`key` vs. `displayName`/`id`)
+
+---
+
+## Baseline-Status
+
+- Datum: 2026-07-12, Branch `refactor-chat-navigation`, Commit `f43c006`
+- `ng build`: ❌ **schlägt fehl** — `NG1: Object is possibly 'null'` in `src/app/features/app_channel/components/add-member/add-member.component.html:39` (`channelService.currentChannel().name`, `currentChannel()` kann `null` sein). → Fix ist Schritt 0 von Phase 1; erst danach ist der Build als Verifikations-Werkzeug nutzbar.

--- a/src/app/features/app_auth/components/register/register.component.html
+++ b/src/app/features/app_auth/components/register/register.component.html
@@ -15,7 +15,9 @@
         <mat-icon class="material-symbols-outlined">person</mat-icon>
         <input name="displayName" type="text" formControlName="displayName" placeholder="Name und Nachname" />
       </div>
-      @if (registerForm.get("displayName")?.invalid && (registerForm.get("displayName")?.touched || registerForm.get("fullname")?.dirty)) {
+      @if (
+        registerForm.get("displayName")?.invalid && (registerForm.get("displayName")?.touched || registerForm.get("displayName")?.dirty)
+      ) {
         <span class="error">Bitte schreiben Sie einen Namen. Mindestens 5 Zeichen</span>
       }
     </section>

--- a/src/app/features/app_auth/models/user/user.ts
+++ b/src/app/features/app_auth/models/user/user.ts
@@ -2,7 +2,7 @@ export interface User {
   id: string;
   email: string;
   displayName: string;
-  photoUrl?: string;
+  photoUrl: string;
   online: boolean;
   isAnonymous?: boolean;
 }

--- a/src/app/features/app_auth/services/auth/auth.service.ts
+++ b/src/app/features/app_auth/services/auth/auth.service.ts
@@ -311,7 +311,7 @@ export class AuthService {
    * - **email**: Inherited from basicAuthFields (Required, Email format).
    * - **password**: Inherited from basicAuthFields (Required, Min length 6).
    * - **displayName**: Required field, minimum of 2 characters.
-   * - **profilephoto**: Optional, defaults to a standard placeholder path.
+   * - **photoURL**: Optional, defaults to a standard placeholder path.
    * - **acceptTerms**: Required to be 'true' (checkbox must be checked).
    * * @returns {FormGroup} A fully configured FormGroup for the registration template.
    */

--- a/src/app/features/app_channel/components/add-channel/add-channel.component.html
+++ b/src/app/features/app_channel/components/add-channel/add-channel.component.html
@@ -98,13 +98,10 @@
 
             @if (channelService.filteredUsers().length > 0) {
               <ul class="choose-user__bar">
-                @for (filteredUser of channelService.filteredUsers(); track filteredUser.id; let index = $index) {
-                  <li class="choose-user__bar__item" (click)="onSelectUser(filteredUser)">
-                    <div class="profile-status">
-                      <img class="profile-status__image" [src]="filteredUser.photoUrl" alt="" />
-                      <div class="profile-status__dot" [ngClass]="{ 'profile-status__dot--online': filteredUser.online }"></div>
-                    </div>
-                    {{ filteredUser.displayName }}
+                @for (user of channelService.filteredUsers(); track user.id; let index = $index) {
+                  <li class="choose-user__bar__item" (click)="onSelectUser(user)">
+                    <app-profile-status [photoUrl]="user.photoUrl" [online]="user.online"></app-profile-status>
+                    {{ user.displayName }}
                   </li>
                 }
               </ul>

--- a/src/app/features/app_channel/components/add-channel/add-channel.component.ts
+++ b/src/app/features/app_channel/components/add-channel/add-channel.component.ts
@@ -92,7 +92,7 @@ export class AddChannelComponent {
         name: name!,
         description: description || '',
         member: this.channelService.membersToSubmit(),
-        creator: this.authService.currentUser()!.displayName,
+        createdBy: this.authService.currentUser()!.id,
         createdAt: new Date(),
       });
 

--- a/src/app/features/app_channel/components/add-channel/add-channel.component.ts
+++ b/src/app/features/app_channel/components/add-channel/add-channel.component.ts
@@ -14,10 +14,11 @@ import { UserService } from '../../../../shared/services/user/shared.service';
 import { FireServiceService } from '../../../../shared/services/firebase/fire-service.service';
 
 import { User } from '../../../app_auth/models/user/user';
+import { ProfileStatusComponent } from '../../../../shared/components/profile-status/profile-status.component';
 
 @Component({
   selector: 'app-add-channel',
-  imports: [CommonModule, FormsModule, NgClass, MatRadioModule, MatIcon, ReactiveFormsModule],
+  imports: [CommonModule, FormsModule, MatRadioModule, MatIcon, ReactiveFormsModule, ProfileStatusComponent],
   templateUrl: './add-channel.component.html',
   styleUrls: ['./add-channel.component.scss'],
 })

--- a/src/app/features/app_channel/components/add-member/add-member.component.html
+++ b/src/app/features/app_channel/components/add-member/add-member.component.html
@@ -36,7 +36,7 @@
       </button>
     </header>
 
-    <div class="channel-name"># {{ channelService.currentChannel().name }}</div>
+    <div class="channel-name"># {{ channelService.currentChannel()?.name }}</div>
 
     <div class="input-wrapper">
       <div class="input-cont">

--- a/src/app/features/app_channel/components/add-member/add-member.component.html
+++ b/src/app/features/app_channel/components/add-member/add-member.component.html
@@ -10,10 +10,7 @@
     <ul class="user__list">
       @for (member of channelService.enrichedMembers(); track $index) {
         <li (click)="openProfileDialog(member)" class="user__list__item">
-          <div class="profile-status">
-            <img class="profile-status__image" [src]="member.photoUrl" alt="" />
-            <div class="profile-status__dot" [ngClass]="{ 'profile-status__dot--online': member.online }"></div>
-          </div>
+          <app-profile-status [photoUrl]="member.photoUrl" [online]="member.online"></app-profile-status>
           <span>
             {{ member.displayName }}
             @if (member.id === authService.currentUser()?.id) {
@@ -55,10 +52,7 @@
             <ul class="choose-user-bar user__list">
               @for (user of channelService.filteredUsers(); track user.id; let index = $index) {
                 <li class="user__list__item" (click)="addUserToSelection(user)">
-                  <div class="profile-status">
-                    <img class="profile-status__image" [src]="user.photoUrl" alt="" />
-                    <div class="profile-status__dot" [ngClass]="{ 'profile-status__dot--online': user.online }"></div>
-                  </div>
+                  <app-profile-status [photoUrl]="user.photoUrl" [online]="user.online"></app-profile-status>
                   {{ user.displayName }}
                 </li>
               } @empty {

--- a/src/app/features/app_channel/components/add-member/add-member.component.ts
+++ b/src/app/features/app_channel/components/add-member/add-member.component.ts
@@ -1,18 +1,18 @@
 import { CommonModule } from '@angular/common';
-import { Component, computed, inject, signal } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
 
 import { DialogReciverComponent } from '../../../dialogs/dialog-reciver/dialog-reciver.component';
-import { FireServiceService } from '../../../../shared/services/firebase/fire-service.service';
 import { AuthService } from '../../../app_auth/services/auth/auth.service';
 import { User } from '../../../app_auth/models/user/user';
 import { ChannelService } from '../../services/channel/channel.service';
 import { MatIcon } from '@angular/material/icon';
 import { FormsModule } from '@angular/forms';
+import { ProfileStatusComponent } from '../../../../shared/components/profile-status/profile-status.component';
 
 @Component({
   selector: 'app-add-member',
-  imports: [CommonModule, MatIcon, FormsModule],
+  imports: [CommonModule, MatIcon, FormsModule, ProfileStatusComponent],
   templateUrl: './add-member.component.html',
   styleUrl: './add-member.component.scss',
 })

--- a/src/app/features/app_channel/components/edit.channel/edit.channel.component.html
+++ b/src/app/features/app_channel/components/edit.channel/edit.channel.component.html
@@ -47,7 +47,7 @@
       <div class="creator">
         Erstellt von
         <div class="creator--name">
-          {{ channelService.currentChannel()?.creator }}
+          {{ channelService.currentChannel()?.createdBy }}
         </div>
       </div>
     </section>

--- a/src/app/features/app_channel/components/edit.channel/edit.channel.component.html
+++ b/src/app/features/app_channel/components/edit.channel/edit.channel.component.html
@@ -58,10 +58,7 @@
       <ul class="member-list">
         @for (member of channelService.enrichedMembers(); track $index) {
           <li (click)="openProfileDialog(member)" class="member-list--item">
-            <div class="profile-status">
-              <img class="profile-status__image" [src]="member.photoUrl" alt="" />
-              <div class="profile-status__dot" [ngClass]="{ 'profile-status__dot--online': member.online }"></div>
-            </div>
+            <app-profile-status [photoUrl]="member.photoUrl" [online]="member.online"></app-profile-status>
             {{ member.displayName }}
           </li>
         }
@@ -102,10 +99,7 @@
           <ul class="choose-user-bar" #chooseUserBar>
             @for (user of channelService.filteredUsers(); track user.id; let i = $index) {
               <li class="user-select-cont" (click)="addUserToSelection(user)">
-                <div class="profile-status">
-                  <img class="profile-status__image" [src]="user.photoUrl" alt="" />
-                  <div class="profile-status__dot" [ngClass]="{ 'profile-status__dot--online': user.online }"></div>
-                </div>
+                <app-profile-status [photoUrl]="user.photoUrl" [online]="user.online"></app-profile-status>
                 {{ user.displayName }}
               </li>
             } @empty {

--- a/src/app/features/app_channel/components/edit.channel/edit.channel.component.ts
+++ b/src/app/features/app_channel/components/edit.channel/edit.channel.component.ts
@@ -9,10 +9,11 @@ import { MatIcon } from '@angular/material/icon';
 import { FormsModule } from '@angular/forms';
 import { ChannelService } from '../../services/channel/channel.service';
 import { Channel } from '../../models/channel/channel';
+import { ProfileStatusComponent } from '../../../../shared/components/profile-status/profile-status.component';
 
 @Component({
   selector: 'app-channel-edit',
-  imports: [CommonModule, MatIcon, FormsModule],
+  imports: [CommonModule, MatIcon, FormsModule, ProfileStatusComponent],
   templateUrl: './edit.channel.component.html',
   styleUrl: './edit.channel.component.scss',
 })

--- a/src/app/features/app_channel/models/channel/channel.ts
+++ b/src/app/features/app_channel/models/channel/channel.ts
@@ -1,8 +1,8 @@
 export interface Channel {
   id?: string;
   name: string;
-  member: { id: String }[];
+  member: { id: string }[];
   description: string;
-  creator: string;
   createdAt: Date;
+  createdBy: string;
 }

--- a/src/app/features/app_chat/components/chat-channel/chat-channel.component.html
+++ b/src/app/features/app_chat/components/chat-channel/chat-channel.component.html
@@ -18,7 +18,7 @@
           <div class="avatar-container hover-bg" (click)="openMemberWindow(false)">
             <div class="member-img-cont">
               @for (member of currentChannel?.member; track $index; let i = $index) {
-                <img *ngIf="i < 3" class="avatar" [src]="member.profilephoto" alt="Name" />
+                <img *ngIf="i < 3" class="avatar" [src]="member.photoURL" alt="Name" />
               }
             </div>
             @if (currentChannel?.member?.length) {
@@ -67,7 +67,6 @@
 
     <section class="card-footer">
       <app-textarea-template
-        [currentUserId]="userId"
         [reciverId]="currentChannelId() || ''"
         [reciverName]="currentChannel?.name"
         [reciverCompontent]="'channel'"

--- a/src/app/features/app_chat/components/chat-channel/chat-channel.component.ts
+++ b/src/app/features/app_chat/components/chat-channel/chat-channel.component.ts
@@ -3,7 +3,7 @@ import { Component, ElementRef, inject, OnInit, ViewChild, OnDestroy, untracked,
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
-import { Firestore, onSnapshot, query, orderBy, collection, doc } from '@angular/fire/firestore';
+import { Firestore, onSnapshot, doc } from '@angular/fire/firestore';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { ActivatedRoute } from '@angular/router';
 import { MatMenuModule } from '@angular/material/menu';
@@ -122,23 +122,6 @@ export class ChatContentComponent implements OnInit, OnDestroy {
         if (docSnap.exists()) {
           this.currentChannel = { id: docSnap.id, ...docSnap.data() };
         }
-      });
-    }
-  }
-
-  /**
-   * Loads the thread (replies) for a specific message.
-   * @param messageId - ID of the message to load the thread for
-   */
-  getThread(messageId: string) {
-    if (messageId) {
-      let threadRef = collection(this.firestore, `channels/${this.currentChannelId()}/messages/${messageId}/thread`);
-      let threadQuery = query(threadRef, orderBy('timestamp', 'asc'));
-
-      onSnapshot(threadQuery, (snapshot) => {
-        // const updatedThreads = this.messagesService.processData(snapshot);
-        // const msgIndex = this.messagesService.messages() ? this.messagesService.messages()?.findIndex((m: any) => m.id === messageId) : -1;
-        // if (msgIndex >= 0) this.messagesService.messages()?[msgIndex].thread = updatedThreads;
       });
     }
   }

--- a/src/app/features/app_chat/components/chat-direct/chat-direct.component.html
+++ b/src/app/features/app_chat/components/chat-direct/chat-direct.component.html
@@ -48,7 +48,6 @@
 
     <footer class="card-footer">
       <app-textarea-template
-        [currentUserId]="currentUserId()"
         [reciverId]="currentRecieverId() || ''"
         [reciverCompontent]="'direct'"
         [messages]="this.messagesService.messages()"

--- a/src/app/features/app_chat/components/chat-direct/chat-direct.component.html
+++ b/src/app/features/app_chat/components/chat-direct/chat-direct.component.html
@@ -5,10 +5,7 @@
   <section (click)="hideList()">
     <div class="chat-header">
       <button (click)="showProfile()">
-        <div class="profile-status">
-          <img class="profile-status__image" [src]="currentReciever()?.photoUrl" alt="" />
-          <div class="profile-status__dot" [ngClass]="{ 'profile-status__dot--online': currentReciever()?.online }"></div>
-        </div>
+        <app-profile-status [photoUrl]="currentReciever()!.photoUrl" [online]="currentReciever()!.online"></app-profile-status>
         {{ currentReciever()?.displayName }}
       </button>
     </div>

--- a/src/app/features/app_chat/components/chat-direct/chat-direct.component.ts
+++ b/src/app/features/app_chat/components/chat-direct/chat-direct.component.ts
@@ -18,6 +18,7 @@ import { User } from '../../../app_auth/models/user/user';
 import { AuthService } from '../../../app_auth/services/auth/auth.service';
 import { TextareaTemplateComponent } from '../textarea/textarea-template.component';
 import { ChatService } from '../../services/chat/chat.service';
+import { ProfileStatusComponent } from '../../../../shared/components/profile-status/profile-status.component';
 
 @Component({
   selector: 'app-direct-messages',
@@ -30,6 +31,7 @@ import { ChatService } from '../../services/chat/chat.service';
     MatDialogModule,
     MessageTemplateComponent,
     ChatHeaderComponent,
+    ProfileStatusComponent,
   ],
   templateUrl: './chat-direct.component.html',
   styleUrl: './chat-direct.component.scss',

--- a/src/app/features/app_chat/components/chat-direct/chat-direct.component.ts
+++ b/src/app/features/app_chat/components/chat-direct/chat-direct.component.ts
@@ -108,10 +108,7 @@ export class DirectmessagesComponent implements OnInit, OnDestroy {
    */
   public showProfile() {
     this.dialog.open(DialogReciverComponent, {
-      data: {
-        reciever: this.currentReciever,
-        recieverId: this.currentRecieverId(),
-      },
+      data: this.currentReciever(),
       width: '400px',
       panelClass: ['center-dialog'],
     });

--- a/src/app/features/app_chat/components/chat-new-message/chat-new.component.html
+++ b/src/app/features/app_chat/components/chat-new-message/chat-new.component.html
@@ -22,9 +22,8 @@
 
     <div class="card-footer">
       <app-textarea-template
-        [placeholderText]="'Starte eine Nachricht an: ' + (currentReceiver.data?.name || currentReceiver.fullname || '...')"
+        [placeholderText]="'Starte eine Nachricht an: ' + (currentReceiver.data?.name || currentReceiver.displayName || '...')"
         [reciverId]="getReceiverId()"
-        [currentUserId]="authService.currentUser()?.id!"
         [reciverCompontent]="isChannel(currentReceiver) ? 'channel' : 'direct'"
       ></app-textarea-template>
     </div>

--- a/src/app/features/app_chat/components/chat-new-message/chat-new.component.html
+++ b/src/app/features/app_chat/components/chat-new-message/chat-new.component.html
@@ -22,7 +22,7 @@
 
     <div class="card-footer">
       <app-textarea-template
-        [placeholderText]="'Starte eine Nachricht an: ' + (currentReceiver.data?.name || currentReceiver.displayName || '...')"
+        [placeholderText]="'Starte eine Nachricht an: ' + (getReceiverName() || '...')"
         [reciverId]="getReceiverId()"
         [reciverCompontent]="isChannel(currentReceiver) ? 'channel' : 'direct'"
       ></app-textarea-template>

--- a/src/app/features/app_chat/components/chat-new-message/chat-new.component.ts
+++ b/src/app/features/app_chat/components/chat-new-message/chat-new.component.ts
@@ -40,7 +40,7 @@ export class NewmessageComponent {
    */
   setReceiver(element: any): void {
     this.currentReceiver = element;
-    this.receiverId = element.key || element.id;
+    this.receiverId = element.id;
 
     this.isChannel(element) ? this.setReceiverType('channel') : this.setReceiverType('direct');
     this.searchService.resetList();
@@ -53,7 +53,7 @@ export class NewmessageComponent {
    * @returns True if the element is a channel, false otherwise.
    */
   public isChannel(element: any): boolean {
-    return element.data?.member;
+    return !!element && typeof element === 'object' && 'member' in element;
   }
 
   /**
@@ -71,8 +71,7 @@ export class NewmessageComponent {
    * @returns The name of the current receiver, or an empty string if not available.
    */
   public getReceiverName(): string {
-    let receiverName = this.currentReceiver?.data?.name || this.currentReceiver?.displayName || '';
-    return receiverName;
+    return this.currentReceiver?.name || this.currentReceiver?.displayName || '';
   }
 
   /**

--- a/src/app/features/app_chat/components/chat-new-message/chat-new.component.ts
+++ b/src/app/features/app_chat/components/chat-new-message/chat-new.component.ts
@@ -71,7 +71,7 @@ export class NewmessageComponent {
    * @returns The name of the current receiver, or an empty string if not available.
    */
   public getReceiverName(): string {
-    let receiverName = this.currentReceiver?.data?.name || this.currentReceiver?.fullname || '';
+    let receiverName = this.currentReceiver?.data?.name || this.currentReceiver?.displayName || '';
     return receiverName;
   }
 

--- a/src/app/features/app_chat/components/chat-new-message/chat-new.component.ts
+++ b/src/app/features/app_chat/components/chat-new-message/chat-new.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, inject, Injectable } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatIconModule } from '@angular/material/icon';
 import { ChatHeaderComponent } from '../chat-header/chat-header.component';
@@ -10,9 +10,6 @@ import { SearchService } from '../../../../shared/services/search/search.service
 import { TextareaTemplateComponent } from '../textarea/textarea-template.component';
 import { AuthService } from '../../../app_auth/services/auth/auth.service';
 
-@Injectable({
-  providedIn: 'root',
-})
 @Component({
   selector: 'app-newmessage',
   imports: [CommonModule, FormsModule, TextareaTemplateComponent, MatIconModule, ChatHeaderComponent, SearchResultComponent],

--- a/src/app/features/app_chat/components/chat-thread/chat-thread.component.html
+++ b/src/app/features/app_chat/components/chat-thread/chat-thread.component.html
@@ -21,7 +21,7 @@
       <li [ngClass]="{ reverse: parentMessageData?.name === this.authService.currentUser()?.displayName }" class="background-color-effect">
         <div class="user-message-container">
           <div class="user-profile-avatar-container">
-            <img src="{{ parentMessageData?.avatar || 'img/profilephoto.png' }}" alt="{{ parentMessageData?.name }}" />
+            <img src="{{ parentMessageData?.avatar || 'img/photoURL.png' }}" alt="{{ parentMessageData?.name }}" />
           </div>
           <div class="name-time-message-container">
             <div class="name-time-container">
@@ -56,7 +56,6 @@
 
     <div class="card-footer" (mouseleave)="listOpen = false">
       <app-textarea-template
-        [currentUserId]="userId"
         [reciverId]="currentChannelId"
         [reciverCompontent]="'thread'"
         [messages]="messages"

--- a/src/app/features/app_chat/components/chat-thread/chat-thread.component.ts
+++ b/src/app/features/app_chat/components/chat-thread/chat-thread.component.ts
@@ -203,8 +203,7 @@ export class ThreadComponent implements OnInit {
     const q = query(channelsRef, where('name', '==', name));
     const snapshot = await getDocs(q);
     const channelDoc = snapshot.docs[0];
-    this.navigationService.setUrl('channel', channelDoc.id);
-    this.navigationService.showChannel();
+    this.navigationService.selectChannel(channelDoc.id);
   }
 
   ngOnDestroy(): void {

--- a/src/app/features/app_chat/components/chat-thread/chat-thread.component.ts
+++ b/src/app/features/app_chat/components/chat-thread/chat-thread.component.ts
@@ -185,7 +185,7 @@ export class ThreadComponent implements OnInit {
    */
   async caseUser(name: string) {
     const usersRef = collection(this.firestore, 'users');
-    const q = query(usersRef, where('fullname', '==', name));
+    const q = query(usersRef, where('displayName', '==', name));
     const snapshot = await getDocs(q);
     const userDoc = snapshot.docs[0];
     this.navigationService.selectDirectMessageRecipient(userDoc.id);

--- a/src/app/features/app_chat/components/contactbar/contactbar.component.html
+++ b/src/app/features/app_chat/components/contactbar/contactbar.component.html
@@ -103,10 +103,7 @@
                 (click)="navigationService.selectDirectMessageRecipient(user.id)"
                 [class.active-link]="router.url.includes('direct/' + user.id)"
               >
-                <div class="profile-status">
-                  <img class="profile-status__image" [src]="user.photoUrl" alt="" />
-                  <div class="profile-status__dot" [ngClass]="{ 'profile-status__dot--online': user.online }"></div>
-                </div>
+                <app-profile-status [photoUrl]="user.photoUrl" [online]="user.online"></app-profile-status>
 
                 {{ user.displayName }}
               </li>

--- a/src/app/features/app_chat/components/contactbar/contactbar.component.html
+++ b/src/app/features/app_chat/components/contactbar/contactbar.component.html
@@ -66,7 +66,7 @@
             @for (channel of firestoreService.myChannels(); track channel.id) {
               <li
                 class="dropdown__list__item"
-                (click)="navigationService.selectChannel(channel.id)"
+                (click)="navigationService.selectChannel(channel.id!)"
                 [class.active-link]="router.url.includes('channel/' + channel.id)"
               >
                 <mat-icon class="material-symbols-outlined">tag</mat-icon>

--- a/src/app/features/app_chat/components/contactbar/contactbar.component.ts
+++ b/src/app/features/app_chat/components/contactbar/contactbar.component.ts
@@ -13,11 +13,12 @@ import { FireServiceService } from '../../../../shared/services/firebase/fire-se
 import { NavigationService } from '../../../../shared/services/navigation/navigation.service';
 import { SearchService } from '../../../../shared/services/search/search.service';
 import { AddChannelComponent } from '../../../app_channel/components/add-channel/add-channel.component';
+import { ProfileStatusComponent } from '../../../../shared/components/profile-status/profile-status.component';
 
 @Component({
   selector: 'app-contactbar',
   standalone: true,
-  imports: [CommonModule, HeaderComponent, MatIconModule, FormsModule, SearchResultComponent, RouterModule],
+  imports: [CommonModule, HeaderComponent, MatIconModule, FormsModule, SearchResultComponent, RouterModule, ProfileStatusComponent],
   templateUrl: './contactbar.component.html',
   styleUrl: './contactbar.component.scss',
 })

--- a/src/app/features/app_chat/components/divider/divider-template.component.ts
+++ b/src/app/features/app_chat/components/divider/divider-template.component.ts
@@ -12,7 +12,6 @@ export class DividerTemplateComponent {
   formattedDate = computed(() => {
     const raw = this.messageData();
     if (!raw) return '';
-    console.log(raw);
 
     const date = typeof raw.toDate === 'function' ? raw.toDate() : new Date(raw);
 

--- a/src/app/features/app_chat/components/message/message-template.component.ts
+++ b/src/app/features/app_chat/components/message/message-template.component.ts
@@ -18,6 +18,7 @@ import { DialogReciverComponent } from '../../../dialogs/dialog-reciver/dialog-r
 import { ChannelMessage } from '../../models/channel-message/channel-message';
 import { AuthService } from '../../../app_auth/services/auth/auth.service';
 import { DirectMessage } from '../../models/direct-message/direct-message';
+import { User } from '../../../app_auth/models/user/user';
 
 @Component({
   selector: 'app-message-template',
@@ -242,12 +243,9 @@ export class MessageTemplateComponent {
    * Displays the receiver's profile.
    */
   public async showProfile() {
-    const reciverData = await this.getReceiverIdByName();
+    const reciverData = await this._getReceiverByName();
     this.dialog.open(DialogReciverComponent, {
-      data: {
-        reciever: reciverData,
-        recieverId: reciverData?.id,
-      },
+      data: reciverData,
       width: '400px',
       panelClass: ['center-dialog'],
     });
@@ -260,15 +258,23 @@ export class MessageTemplateComponent {
    * @returns A promise that resolves to the user data object including the document ID,
    *          or null if no matching user is found.
    */
-  private async getReceiverIdByName() {
+  private async _getReceiverByName(): Promise<User | null> {
     const usersCollection = this.fireService.getCollectionRef('users');
-    const q = query(usersCollection!, where('displayName', '==', this.message().name || ''));
+    const searchName = this.message().name;
+    if (!searchName) return null;
+
+    const q = query(usersCollection!, where('displayName', '==', searchName));
     const querySnapshot = await getDocs(q);
 
     if (!querySnapshot.empty) {
       const doc = querySnapshot.docs[0];
-      return { ...doc.data(), id: doc.id };
-    } else return null;
+      const user = {
+        ...(doc.data() as Omit<User, 'id'>),
+        id: doc.id,
+      } as User;
+      return user;
+    }
+    return null;
   }
 
   /**

--- a/src/app/features/app_chat/components/message/message-template.component.ts
+++ b/src/app/features/app_chat/components/message/message-template.component.ts
@@ -223,8 +223,8 @@ export class MessageTemplateComponent {
     let hasCurrentUserReacted = userIds.includes(currentUserId);
 
     let otherUsers = allUsers
-      .filter((user: any) => userIds.includes(user.key) && user.key !== currentUserId)
-      .map((user: any) => user.fullname);
+      .filter((user: any) => userIds.includes(user.id) && user.id !== currentUserId)
+      .map((user: any) => user.displayName);
 
     if (hasCurrentUserReacted) {
       if (otherUsers.length === 0) return ['Du'];
@@ -258,14 +258,15 @@ export class MessageTemplateComponent {
 
   /**
    * Retrieves a user document from Firestore by matching the full name.
-   * Queries the 'users' collection where 'fullname' equals the provided message name.
+   * Queries the 'users' collection where 'displayName' equals the provided message name.
    *
    * @returns A promise that resolves to the user data object including the document ID,
    *          or null if no matching user is found.
    */
   private async getReceiverIdByName() {
+    debugger;
     const usersCollection = this.fireService.getCollectionRef('users');
-    const q = query(usersCollection!, where('fullname', '==', this.message?.name || ''));
+    const q = query(usersCollection!, where('displayName', '==', this.message().name || ''));
     const querySnapshot = await getDocs(q);
 
     if (!querySnapshot.empty) {
@@ -323,7 +324,7 @@ export class MessageTemplateComponent {
    */
   async caseUser(name: string) {
     const usersRef = collection(this.firestore, 'users');
-    const q = query(usersRef, where('fullname', '==', name));
+    const q = query(usersRef, where('displayName', '==', name));
     const snapshot = await getDocs(q);
     const userDoc = snapshot.docs[0];
     this.navigationService.selectDirectMessageRecipient(userDoc.id);

--- a/src/app/features/app_chat/components/message/message-template.component.ts
+++ b/src/app/features/app_chat/components/message/message-template.component.ts
@@ -26,7 +26,6 @@ import { DirectMessage } from '../../models/direct-message/direct-message';
   styleUrl: './message-template.component.scss',
 })
 export class MessageTemplateComponent {
-  public userService: UserService = inject(UserService);
   private fireService: FireServiceService = inject(FireServiceService);
   public authService = inject(AuthService);
   private dialog = inject(MatDialog);
@@ -37,7 +36,6 @@ export class MessageTemplateComponent {
   reactionMenuOpenInFooter: boolean = false;
   isEditing: boolean = false;
   showAllReactions: boolean = false;
-  userId: string | undefined = '';
   inputEdit: string = '';
   emojis: string[] = [
     'emoji _nerd face_',
@@ -72,7 +70,6 @@ export class MessageTemplateComponent {
    * and loading the emoji database.
    */
   constructor() {
-    this.userId = this.authService.currentUser()?.id;
     this.emojiDataBase = emojiData;
   }
 
@@ -157,7 +154,8 @@ export class MessageTemplateComponent {
    * @returns True if the user has reacted, otherwise false
    */
   public hasReacted(emoji: any, reactions: any[]): boolean | undefined {
-    if (this.channelType !== 'direct') return reactions.some((reaction) => reaction.from === this.userId && reaction.emoji === emoji);
+    if (this.channelType !== 'direct')
+      return reactions.some((reaction) => reaction.from === this.authService.currentUser()?.id && reaction.emoji === emoji);
     return;
   }
 
@@ -172,7 +170,7 @@ export class MessageTemplateComponent {
       ? (messageRef = this.fireService.getMessageThreadRef(this.currentChannelId, this.parentMessageId, message.id))
       : (messageRef = this.fireService.getMessageRef(this.currentChannelId, message.id));
 
-    let reactionIndex = message.reaction.findIndex((r: any) => r.from === this.userId && r.emoji === emoji);
+    let reactionIndex = message.reaction.findIndex((r: any) => r.from === this.authService.currentUser()?.id && r.emoji === emoji);
     if (reactionIndex >= 0) {
       message.reaction.splice(reactionIndex, 1);
       if (messageRef) {
@@ -217,13 +215,12 @@ export class MessageTemplateComponent {
    */
   public getReactionNamesForEmoji(targetEmoji: string, reactions: any[]): string[] | any {
     let allUsers = this.fireService.allUsers();
-    let currentUserId = this.userId;
     let reactionsWithEmoji = reactions.filter((reaction: any) => reaction.emoji === targetEmoji);
     let userIds = reactionsWithEmoji.map((reaction: any) => reaction.from);
-    let hasCurrentUserReacted = userIds.includes(currentUserId);
+    let hasCurrentUserReacted = userIds.includes(this.authService.currentUser()?.id);
 
     let otherUsers = allUsers
-      .filter((user: any) => userIds.includes(user.id) && user.id !== currentUserId)
+      .filter((user: any) => userIds.includes(user.id) && user.id !== this.authService.currentUser()?.id)
       .map((user: any) => user.displayName);
 
     if (hasCurrentUserReacted) {
@@ -264,7 +261,6 @@ export class MessageTemplateComponent {
    *          or null if no matching user is found.
    */
   private async getReceiverIdByName() {
-    debugger;
     const usersCollection = this.fireService.getCollectionRef('users');
     const q = query(usersCollection!, where('displayName', '==', this.message().name || ''));
     const querySnapshot = await getDocs(q);
@@ -342,7 +338,6 @@ export class MessageTemplateComponent {
     const q = query(channelsRef, where('name', '==', name));
     const snapshot = await getDocs(q);
     const channelDoc = snapshot.docs[0];
-    this.navigationService.setUrl('channel', channelDoc.id);
-    this.navigationService.showChannel();
+    this.navigationService.selectChannel(channelDoc.id);
   }
 }

--- a/src/app/features/app_chat/components/textarea/textarea-template.component.html
+++ b/src/app/features/app_chat/components/textarea/textarea-template.component.html
@@ -1,7 +1,7 @@
 <div (mouseleave)="reactionMenuOpenInTextarea = false" (click)="reactionMenuOpenInTextarea = false" class="input-container">
   <textarea
     (keyup.enter)="newMessage()"
-    (click)="searchService.closeList(); searchService.setIsDirectTag(false)"
+    (click)="searchService.closeList(); searchService.setIsDirectTag(false); searchService.resetObserveInput()"
     (input)="searchService.observeInput(input, 'textarea')"
     [(ngModel)]="input"
     rows="3"
@@ -12,9 +12,9 @@
   <div class="action-container justify-sb">
     <div class="gap-10">
       @if (isChannelComponent) {
-      <button class="btn" (click)="reactionMenuOpenInTextarea = !reactionMenuOpenInTextarea; $event.stopPropagation()">
-        <mat-icon>sentiment_satisfied</mat-icon>
-      </button>
+        <button class="btn" (click)="reactionMenuOpenInTextarea = !reactionMenuOpenInTextarea; $event.stopPropagation()">
+          <mat-icon>sentiment_satisfied</mat-icon>
+        </button>
       }
 
       <button class="btn" (click)="searchService.getList('@'); $event.stopPropagation()">
@@ -29,21 +29,20 @@
     </button>
 
     @if (searchService.getListBoolean()) {
-
-    <div class="tag-container">
-      <app-search-result [input]="input" (tagInserted)="onTagInserted($event)"></app-search-result>
-    </div>
-
-    } @if (reactionMenuOpenInTextarea) {
-    <div class="reaction-menu">
-      <div class="scroll-container">
-        @for (emoji of emojis; track $index) {
-        <span (click)="addEmoji(emoji); reactionMenuOpenInTextarea = false" class="emoji">
-          {{ emoji }}
-        </span>
-        }
+      <div class="tag-container">
+        <app-search-result [input]="input" (tagInserted)="onTagInserted($event)"></app-search-result>
       </div>
-    </div>
+    }
+    @if (reactionMenuOpenInTextarea) {
+      <div class="reaction-menu">
+        <div class="scroll-container">
+          @for (emoji of emojis; track $index) {
+            <span (click)="addEmoji(emoji); reactionMenuOpenInTextarea = false" class="emoji">
+              {{ emoji }}
+            </span>
+          }
+        </div>
+      </div>
     }
   </div>
 </div>

--- a/src/app/features/app_chat/components/textarea/textarea-template.component.ts
+++ b/src/app/features/app_chat/components/textarea/textarea-template.component.ts
@@ -38,7 +38,17 @@ export class TextareaTemplateComponent {
   }
 
   onTagInserted(tagName: string) {
-    this.input += ` ${tagName} `;
+    const query = this.searchService.searchQuery;
+
+    if (query && this.input.includes(query)) {
+      const symbol = query.charAt(0);
+      const fullTag = tagName.startsWith(symbol) ? tagName : symbol + tagName;
+
+      this.input = this.input.replace(query, fullTag) + ' ';
+    } else {
+      this.input = `${tagName} `;
+    }
+
     this.taggedNames.push(tagName);
   }
 

--- a/src/app/features/app_chat/components/textarea/textarea-template.component.ts
+++ b/src/app/features/app_chat/components/textarea/textarea-template.component.ts
@@ -4,10 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { MatIcon } from '@angular/material/icon';
 import emojiData from 'unicode-emoji-json';
 import { SearchResultComponent } from '../../../../shared/components/search-result/search-result.component';
-import { FireServiceService } from '../../../../shared/services/firebase/fire-service.service';
 import { SearchService } from '../../../../shared/services/search/search.service';
-import { ChannelMessage } from '../../models/channel-message/channel-message';
-import { AuthService } from '../../../app_auth/services/auth/auth.service';
 import { MessagesService } from '../../services/messages/messages.service';
 
 @Component({
@@ -19,13 +16,11 @@ import { MessagesService } from '../../services/messages/messages.service';
 export class TextareaTemplateComponent {
   private messagesService = inject(MessagesService);
   public searchService: SearchService = inject(SearchService);
-  private authService = inject(AuthService);
   public reactionMenuOpenInTextarea: boolean = false;
   public input: string = '';
   private taggedNames: string[] = [];
 
   public emojis: any;
-  @Input() currentUserId: string = '';
   @Input() reciverId: string = '';
   @Input() reciverName: string = '';
   @Input() messages: any[] = [];

--- a/src/app/features/app_chat/main-chat/main-chat.component.html
+++ b/src/app/features/app_chat/main-chat/main-chat.component.html
@@ -39,6 +39,6 @@
   </aside>
 }
 
-@if (feedbackVisible) {
-  <div #feedback class="feedback-cont"></div>
+@if (userService.feedbackMessage(); as feedback) {
+  <div class="feedback-cont">{{ feedback }}</div>
 }

--- a/src/app/features/app_chat/main-chat/main-chat.component.ts
+++ b/src/app/features/app_chat/main-chat/main-chat.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, ViewChild, OnInit, ChangeDetectorRef, ElementRef, AfterViewInit, signal } from '@angular/core';
+import { Component, inject, ViewChild, signal } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDividerModule } from '@angular/material/divider';
@@ -9,6 +9,7 @@ import { MatDrawer, MatSidenavModule } from '@angular/material/sidenav';
 import { HeaderComponent } from '../../../shared/components/header/header.component';
 import { NavigationService } from '../../../shared/services/navigation/navigation.service';
 import { SearchService } from '../../../shared/services/search/search.service';
+import { UserService } from '../../../shared/services/user/shared.service';
 import { RouterModule } from '@angular/router';
 import { ThreadComponent } from '../components/chat-thread/chat-thread.component';
 import { ContactbarComponent } from '../components/contactbar/contactbar.component';
@@ -33,29 +34,12 @@ import { ContactbarComponent } from '../components/contactbar/contactbar.compone
 export class MainChatComponent {
   @ViewChild('drawer') drawer!: MatDrawer;
   @ViewChild('drawerContactbar') drawerContactbar!: MatDrawer;
-  @ViewChild('feedback') feedbackRef!: ElementRef<HTMLDivElement>;
   public readonly navigationService: NavigationService = inject(NavigationService);
+  public readonly userService: UserService = inject(UserService);
   private searchService: SearchService = inject(SearchService);
 
-  public feedbackVisible: boolean = false;
   public barOpen = signal<boolean>(true);
   public isChatOverlayVisible: boolean = false;
-
-  /**
-   * Displays a feedback message for a brief period.
-   * @param message - The message to display.
-   */
-  public showFeedback(message: string) {
-    this.feedbackVisible = true;
-    setTimeout(() => {
-      if (this.feedbackRef) {
-        this.feedbackRef.nativeElement.textContent = message;
-      }
-    });
-    setTimeout(() => {
-      this.feedbackVisible = false;
-    }, 1000);
-  }
 
   /**
    * Toggles the visibility of the contact bar.

--- a/src/app/features/app_chat/services/messages/messages.service.ts
+++ b/src/app/features/app_chat/services/messages/messages.service.ts
@@ -11,7 +11,6 @@ import { AuthService } from '../../../app_auth/services/auth/auth.service';
 export class MessagesService {
   private fireService = inject(FireServiceService);
   private readonly authService = inject(AuthService);
-  email = 'gianniskarakasidhs@hotmail.com';
 
   public messages = signal<ChannelMessage[] | DirectMessage[]>([]);
 

--- a/src/app/features/dialogs/dialog-reciver/dialog-reciver.component.ts
+++ b/src/app/features/dialogs/dialog-reciver/dialog-reciver.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { NavigationService } from '../../../shared/services/navigation/navigation.service';
@@ -10,14 +10,10 @@ import { User } from '../../app_auth/models/user/user';
   templateUrl: './dialog-reciver.component.html',
   styleUrl: './dialog-reciver.component.scss',
 })
-export class DialogReciverComponent implements OnInit {
+export class DialogReciverComponent {
   public readonly reciverData = inject<User>(MAT_DIALOG_DATA);
   private readonly dialogRef = inject(MatDialogRef<DialogReciverComponent>);
   private readonly navigationService = inject(NavigationService);
-
-  ngOnInit(): void {
-    console.log(this.reciverData);
-  }
 
   /**
    * Opens a direct chat with the selected receiver.

--- a/src/app/features/legal/data-protection/data-protection.component.html
+++ b/src/app/features/legal/data-protection/data-protection.component.html
@@ -153,7 +153,7 @@
         <p>12351 Agia Barbara</p>
         <p>Griechenland</p>
         <p>Tel.: +306981726289</p>
-        <p>E-Mail: {{ message.email }}</p>
+        <p>E-Mail: {{ contactEmail }}</p>
         <p>Website: https://dabubble-396.developerakademie.net/</p>
 
         <h4>3. Erfassung von allgemeinen Daten und Informationen</h4>

--- a/src/app/features/legal/data-protection/data-protection.component.ts
+++ b/src/app/features/legal/data-protection/data-protection.component.ts
@@ -1,7 +1,7 @@
-import { Component, inject } from '@angular/core';
+import { Component } from '@angular/core';
 
-import { MessagesService } from '../../app_chat/services/messages/messages.service';
 import { HeaderComponent } from '../../../shared/components/header/header.component';
+import { CONTACT_EMAIL } from '../../../shared/constants';
 
 @Component({
   selector: 'app-dataprotection',
@@ -10,5 +10,5 @@ import { HeaderComponent } from '../../../shared/components/header/header.compon
   styleUrl: './data-protection.component.scss',
 })
 export class DataprotectionComponent {
-  message = inject(MessagesService);
+  protected readonly contactEmail = CONTACT_EMAIL;
 }

--- a/src/app/features/legal/imprint/imprint.component.html
+++ b/src/app/features/legal/imprint/imprint.component.html
@@ -13,7 +13,7 @@
       </div>
       <div>
         <h2>Contact:</h2>
-        <p>Email: {{ message.email }}</p>
+        <p>Email: {{ contactEmail }}</p>
       </div>
     </div>
   </div>

--- a/src/app/features/legal/imprint/imprint.component.ts
+++ b/src/app/features/legal/imprint/imprint.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject } from '@angular/core';
 import { HeaderComponent } from '../../../shared/components/header/header.component';
 import { NavigationService } from '../../../shared/services/navigation/navigation.service';
-import { MessagesService } from '../../app_chat/services/messages/messages.service';
+import { CONTACT_EMAIL } from '../../../shared/constants';
 
 @Component({
   selector: 'app-imprint',
@@ -11,5 +11,5 @@ import { MessagesService } from '../../app_chat/services/messages/messages.servi
 })
 export class ImprintComponent {
   navigate = inject(NavigationService);
-  message = inject(MessagesService);
+  protected readonly contactEmail = CONTACT_EMAIL;
 }

--- a/src/app/shared/components/profile-status/profile-status.component.html
+++ b/src/app/shared/components/profile-status/profile-status.component.html
@@ -1,0 +1,4 @@
+<div class="profile-status">
+  <img class="profile-status__image" [src]="photoUrl()" alt="Profilbild" />
+  <div class="profile-status__dot" [ngClass]="{ 'profile-status__dot--online': online() }"></div>
+</div>

--- a/src/app/shared/components/profile-status/profile-status.component.scss
+++ b/src/app/shared/components/profile-status/profile-status.component.scss
@@ -1,0 +1,26 @@
+.profile-status {
+  position: relative;
+  display: inline-flex;
+
+  &__image {
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    object-fit: cover;
+  }
+
+  &__dot {
+    position: absolute;
+    bottom: 0;
+    right: -4px;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    border: 2px solid #ffffff;
+    background-color: var(--offline);
+
+    &--online {
+      background-color: var(--online);
+    }
+  }
+}

--- a/src/app/shared/components/profile-status/profile-status.component.spec.ts
+++ b/src/app/shared/components/profile-status/profile-status.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProfileStatusComponent } from './profile-status.component';
+
+describe('ProfileStatusComponent', () => {
+  let component: ProfileStatusComponent;
+  let fixture: ComponentFixture<ProfileStatusComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ProfileStatusComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ProfileStatusComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/profile-status/profile-status.component.ts
+++ b/src/app/shared/components/profile-status/profile-status.component.ts
@@ -1,0 +1,13 @@
+import { CommonModule } from '@angular/common';
+import { Component, input } from '@angular/core';
+
+@Component({
+  selector: 'app-profile-status',
+  imports: [CommonModule],
+  templateUrl: './profile-status.component.html',
+  styleUrl: './profile-status.component.scss',
+})
+export class ProfileStatusComponent {
+  photoUrl = input.required<string>();
+  online = input<boolean>(false);
+}

--- a/src/app/shared/components/search-result/search-result.component.html
+++ b/src/app/shared/components/search-result/search-result.component.html
@@ -5,10 +5,8 @@
         <div><mat-icon>tag</mat-icon></div>
         {{ element.name }}
       } @else if (isUser(element)) {
-        <div class="profile-status">
-          <img class="profile-status__image" [src]="element.photoUrl" alt="" />
-          <div class="profile-status__dot" [ngClass]="{ 'profile-status__dot--online': element.online }"></div>
-        </div>
+        <app-profile-status [photoUrl]="element.photoUrl" [online]="element.online"></app-profile-status>
+
         {{ element.displayName }}
       }
     </li>

--- a/src/app/shared/components/search-result/search-result.component.html
+++ b/src/app/shared/components/search-result/search-result.component.html
@@ -12,9 +12,9 @@
     </li>
   } @empty {
     Kein
-    @if (searchService.getChannelBoolean() === true) {
+    @if (searchService.isChannel() === true) {
       Channel
-    } @else if (searchService.getChannelBoolean() === false) {
+    } @else if (searchService.isChannel() === false) {
       Nutzer
     } @else {
       Eintrag

--- a/src/app/shared/components/search-result/search-result.component.html
+++ b/src/app/shared/components/search-result/search-result.component.html
@@ -1,25 +1,16 @@
 <ul>
   @for (element of searchService.getCurrentList(); track $index) {
     <li (click)="handleClick(element)">
-      @if (searchService.getChannelBoolean() === true) {
+      @if (isChannel(element)) {
         <div><mat-icon>tag</mat-icon></div>
-      } @else if (searchService.getChannelBoolean() === false) {
-        <div class="userCircle">
-          <img class="profilephoto" src="{{ element?.profilephoto }}" alt="" />
-          <div class="status-dot" [ngClass]="{ online: element?.online }"></div>
+        {{ element.name }}
+      } @else if (isUser(element)) {
+        <div class="profile-status">
+          <img class="profile-status__image" [src]="element.photoUrl" alt="" />
+          <div class="profile-status__dot" [ngClass]="{ 'profile-status__dot--online': element.online }"></div>
         </div>
-      } @else {
-        @if (element.data?.name) {
-          <div><mat-icon>tag</mat-icon></div>
-        } @else {
-          <div class="profile-status">
-            <img class="profile-status__image" [src]="element.photoUrl" alt="" />
-            <div class="profile-status__dot" [ngClass]="{ 'profile-status__dot--online': element?.online }"></div>
-          </div>
-        }
+        {{ element.displayName }}
       }
-
-      {{ element.fullname || element.data.name }}
     </li>
   } @empty {
     Kein

--- a/src/app/shared/components/search-result/search-result.component.ts
+++ b/src/app/shared/components/search-result/search-result.component.ts
@@ -3,7 +3,6 @@ import { SearchService } from '../../services/search/search.service';
 import { MatIcon } from '@angular/material/icon';
 import { CommonModule } from '@angular/common';
 import { NavigationService } from '../../services/navigation/navigation.service';
-import { Auth } from '@angular/fire/auth';
 import { Channel } from '../../../features/app_channel/models/channel/channel';
 import { User } from '../../../features/app_auth/models/user/user';
 
@@ -16,7 +15,6 @@ import { User } from '../../../features/app_auth/models/user/user';
 export class SearchResultComponent {
   searchService: SearchService = inject(SearchService);
   navigationService: NavigationService = inject(NavigationService);
-  auth: Auth = inject(Auth);
 
   @Input() input: string = '';
   @Output() inputChange = new EventEmitter<string>();
@@ -32,6 +30,7 @@ export class SearchResultComponent {
    */
   public tagReceiver(receiverData: Channel | User, tagType: '@' | '#') {
     const tagName = this.isChannel(receiverData) ? receiverData.name : receiverData.displayName;
+
     this.searchService.isDirectTag() ? this.tagInserted.emit(tagType + tagName) : this.tagInserted.emit(tagName);
 
     this.searchService.closeList();
@@ -67,9 +66,7 @@ export class SearchResultComponent {
    * @param element - The channel element to open.
    */
   private openChannel(element: any) {
-    let currentUserId = this.auth.currentUser?.uid;
-    this.navigationService.showChannel();
-    this.navigationService.setUrl('channel', element.key, currentUserId);
+    this.navigationService.selectChannel(element.id);
     this.searchService.resetList();
   }
 

--- a/src/app/shared/components/search-result/search-result.component.ts
+++ b/src/app/shared/components/search-result/search-result.component.ts
@@ -5,10 +5,11 @@ import { CommonModule } from '@angular/common';
 import { NavigationService } from '../../services/navigation/navigation.service';
 import { Channel } from '../../../features/app_channel/models/channel/channel';
 import { User } from '../../../features/app_auth/models/user/user';
+import { ProfileStatusComponent } from '../profile-status/profile-status.component';
 
 @Component({
   selector: 'app-search-result',
-  imports: [MatIcon, CommonModule],
+  imports: [MatIcon, CommonModule, ProfileStatusComponent],
   templateUrl: './search-result.component.html',
   styleUrl: './search-result.component.scss',
 })

--- a/src/app/shared/components/search-result/search-result.component.ts
+++ b/src/app/shared/components/search-result/search-result.component.ts
@@ -4,6 +4,8 @@ import { MatIcon } from '@angular/material/icon';
 import { CommonModule } from '@angular/common';
 import { NavigationService } from '../../services/navigation/navigation.service';
 import { Auth } from '@angular/fire/auth';
+import { Channel } from '../../../features/app_channel/models/channel/channel';
+import { User } from '../../../features/app_auth/models/user/user';
 
 @Component({
   selector: 'app-search-result',
@@ -28,8 +30,8 @@ export class SearchResultComponent {
    * @param receiverData - The data object of the receiver (user or channel).
    * @param tagType - The tag symbol to use (e.g., '@' for user, '#' for channel).
    */
-  public tagReceiver(receiverData: any, tagType: '@' | '#') {
-    const tagName = receiverData.fullname || receiverData.data.name;
+  public tagReceiver(receiverData: Channel | User, tagType: '@' | '#') {
+    const tagName = this.isChannel(receiverData) ? receiverData.name : receiverData.displayName;
     this.searchService.isDirectTag() ? this.tagInserted.emit(tagType + tagName) : this.tagInserted.emit(tagName);
 
     this.searchService.closeList();
@@ -77,6 +79,16 @@ export class SearchResultComponent {
   setReceiver(element: any) {
     this.currentReceiver.emit(element);
     this.searchService.resetList();
+  }
+
+  // Prüft, ob das Element ein Channel ist
+  isChannel(element: User | Channel): element is Channel {
+    return 'member' in element;
+  }
+
+  // Prüft, ob das Element ein User ist
+  isUser(element: User | Channel): element is User {
+    return 'displayName' in element;
   }
 
   /**

--- a/src/app/shared/components/search-result/search-result.component.ts
+++ b/src/app/shared/components/search-result/search-result.component.ts
@@ -44,11 +44,9 @@ export class SearchResultComponent {
    * @param element - The selected receiver element (channel or user).
    */
   public openReceiver(element: any) {
-    element.online === false || element.online === true
-      ? this.searchService.setChannelBoolean(false)
-      : this.searchService.setChannelBoolean(true);
-
-    this.searchService.getChannelBoolean() ? this.openChannel(element) : this.openUser(element);
+    const isChannel = typeof element.online !== 'boolean';
+    this.searchService.isChannel.set(isChannel);
+    isChannel ? this.openChannel(element) : this.openUser(element);
   }
 
   /**
@@ -106,7 +104,7 @@ export class SearchResultComponent {
         break;
 
       case 'textarea':
-        this.tagReceiver(element, this.searchService.getChannelBoolean() === true ? '#' : '@');
+        this.tagReceiver(element, this.searchService.isChannel() ? '#' : '@');
         break;
 
       default:

--- a/src/app/shared/constants.ts
+++ b/src/app/shared/constants.ts
@@ -1,0 +1,1 @@
+export const CONTACT_EMAIL = 'gianniskarakasidhs@hotmail.com';

--- a/src/app/shared/services/firebase/fire-service.service.ts
+++ b/src/app/shared/services/firebase/fire-service.service.ts
@@ -16,6 +16,7 @@ import {
 } from '@angular/fire/firestore';
 import { ChannelMessage } from '../../../features/app_chat/models/channel-message/channel-message';
 import { User } from '../../../features/app_auth/models/user/user';
+import { Channel } from '../../../features/app_channel/models/channel/channel';
 import { AuthService } from '../../../features/app_auth/services/auth/auth.service';
 
 @Injectable({
@@ -58,34 +59,13 @@ export class FireServiceService {
               ...doc.data(),
             }) as User,
         );
-
         this.allUsers.set(users);
-        console.log(users);
       },
       (error) => {
         console.error('Fehler beim User-Streaming:', error);
       },
     );
   }
-
-  public myChannels = computed(() => {
-    const authService = this.injector.get(AuthService);
-    const channels = this._allChannels();
-    const currentUser = authService.currentUser();
-    const DEFAULT_CHANNEL_ID = 'KqvcY68R1jP2UsQkv6Nz';
-
-    if (!currentUser) return [];
-
-    const isGuest = currentUser.email === 'gast@portfolio.de';
-
-    return channels.filter((channel) => {
-      if (isGuest) {
-        return channel.id === DEFAULT_CHANNEL_ID || channel.createdBy === currentUser.id;
-      }
-
-      return channel.member?.some((m: any) => m.id === currentUser.id);
-    });
-  });
 
   /**
    * Startet den Echtzeit-Stream für alle Channels
@@ -102,24 +82,22 @@ export class FireServiceService {
     });
   }
 
-  /**
-   * Retrieves all channels from Firestore.
-   *
-   * @returns A promise that resolves with an array of channel objects.
-   * @throws If there is an error fetching channels from Firestore.
-   */
-  async getChannels() {
-    try {
-      const channelCollection = collection(this.firestore, 'channels');
-      const channelSnapshot = await getDocs(channelCollection);
-      return channelSnapshot.docs.map((doc) => ({
-        id: doc.id,
-        ...doc.data(),
-      }));
-    } catch (error) {
-      throw error;
-    }
-  }
+  public myChannels = computed(() => {
+    const authService = this.injector.get(AuthService);
+    const channels: Channel[] = this._allChannels();
+    const currentUser = authService.currentUser();
+    const DEFAULT_CHANNEL_ID = 'KqvcY68R1jP2UsQkv6Nz';
+
+    if (!currentUser) return [];
+
+    const isGuest = currentUser.email === 'gast@portfolio.de';
+    return channels.filter((channel) => {
+      if (isGuest) {
+        return channel.id === DEFAULT_CHANNEL_ID || channel.createdBy === currentUser.id;
+      }
+      return channel.member.some((m: { id: string }) => m.id === currentUser.id);
+    });
+  });
 
   /**
    * Returns a reference to a specific document in Firestore.

--- a/src/app/shared/services/navigation/navigation.service.ts
+++ b/src/app/shared/services/navigation/navigation.service.ts
@@ -103,7 +103,6 @@ export class NavigationService {
       )
       .subscribe((isMobileNow) => {
         this.isMobile.set(isMobileNow);
-        console.log('Mobile Mode:', isMobileNow);
         if (!isMobileNow && this.router.url === '/main') {
           this.router.navigate(['/main/new-message']);
         }

--- a/src/app/shared/services/navigation/navigation.service.ts
+++ b/src/app/shared/services/navigation/navigation.service.ts
@@ -118,11 +118,5 @@ export class NavigationService {
     return window.innerWidth < 1024;
   }
 
-  public setUrl(a: any, b: any, c?: any) {
-    console.log('test');
-  }
-
-  public showChannel() {}
-
   public toggleThread(a: any) {}
 }

--- a/src/app/shared/services/search/search.service.ts
+++ b/src/app/shared/services/search/search.service.ts
@@ -1,6 +1,4 @@
 import { inject, Injectable } from '@angular/core';
-import { UserService } from '../user/shared.service';
-import { AuthService } from '../../../features/app_auth/services/auth/auth.service';
 import { FireServiceService } from '../firebase/fire-service.service';
 import { Channel } from '../../../features/app_channel/models/channel/channel';
 import { User } from '../../../features/app_auth/models/user/user';
@@ -9,9 +7,6 @@ import { User } from '../../../features/app_auth/models/user/user';
   providedIn: 'root',
 })
 export class SearchService {
-  constructor() {}
-  private authService: AuthService = inject(AuthService);
-  private userService: UserService = inject(UserService);
   private fireService: FireServiceService = inject(FireServiceService);
 
   private textareaListOpen: boolean = false;
@@ -24,7 +19,7 @@ export class SearchService {
   private currentList: (User | Channel)[] = [];
   private tagType: 'channel' | 'user' | null = null;
   private searchInComponent: 'header' | 'textarea' | 'newMessage' | null = null;
-  private input: string = '';
+  public searchQuery: string = '';
 
   /**
    * Returns the current Search Component.
@@ -117,14 +112,22 @@ export class SearchService {
   }
 
   /**
+   * Reset observing input to prevent triggering further search actions.
+   */
+  public resetObserveInput(): void {
+    this.setResult(false);
+  }
+
+  /**
    * Observes user input and determines whether to search for users or channels.
    * @param input - The input string entered by the user.
    * @param searchInComponent - The context where the input comes from: 'textarea' or 'header'.
    */
   public observeInput(input: string, searchInComponent: 'textarea' | 'header' | 'newMessage'): void {
+    if (this.isResultTrue) return;
     this.headerListOpen = false;
     this.textareaListOpen = false;
-    this.input = input;
+    this.searchQuery = input;
     this.searchInComponent = searchInComponent;
 
     this.getTagType(input);
@@ -140,7 +143,9 @@ export class SearchService {
    */
   private isNoTagSearch() {
     return (
-      (this.searchInComponent === 'header' || this.searchInComponent === 'newMessage') && this.tagType == null && this.input.length > 0
+      (this.searchInComponent === 'header' || this.searchInComponent === 'newMessage') &&
+      this.tagType == null &&
+      this.searchQuery.length > 0
     );
   }
 
@@ -148,8 +153,8 @@ export class SearchService {
    * Handles search when no tag is used, searching for both users and channels.
    */
   private searchWithoutTag() {
-    let userResults = this.startSearch(this.input, 'user');
-    let channelResults = this.startSearch(this.input, 'channel');
+    let userResults = this.startSearch(this.searchQuery, 'user');
+    let channelResults = this.startSearch(this.searchQuery, 'channel');
     this.currentList = [...userResults, ...channelResults];
     this.textareaListOpen = false;
     this.searchInComponent === 'header' ? (this.headerListOpen = true) : (this.headerListOpen = false);
@@ -182,7 +187,7 @@ export class SearchService {
   private caseChannel() {
     let searchInput: string | null = null;
     this.isChannel = true;
-    searchInput = this.input.split('#')[1];
+    searchInput = this.searchQuery.split('#')[1];
     this.currentList = this.startSearch(searchInput, 'channel');
 
     this.searchInComponent === 'textarea' ? (this.textareaListOpen = true) : (this.headerListOpen = true);
@@ -195,7 +200,7 @@ export class SearchService {
   private caseUser() {
     let searchInput: string | null = null;
     this.isChannel = false;
-    searchInput = this.input.split('@')[1];
+    searchInput = this.searchQuery.split('@')[1];
     this.currentList = this.startSearch(searchInput, 'user');
 
     this.searchInComponent === 'textarea' ? (this.textareaListOpen = true) : (this.headerListOpen = true);

--- a/src/app/shared/services/search/search.service.ts
+++ b/src/app/shared/services/search/search.service.ts
@@ -1,4 +1,4 @@
-import { inject, Injectable } from '@angular/core';
+import { inject, Injectable, signal } from '@angular/core';
 import { FireServiceService } from '../firebase/fire-service.service';
 import { Channel } from '../../../features/app_channel/models/channel/channel';
 import { User } from '../../../features/app_auth/models/user/user';
@@ -12,7 +12,7 @@ export class SearchService {
   private textareaListOpen: boolean = false;
   private headerListOpen: boolean = false;
   private newMessageListOpen: boolean = false;
-  private isChannel: boolean | null = false;
+  public isChannel = signal<boolean | null>(false);
   private isResultTrue: boolean = false;
   private directTag: boolean = false;
 
@@ -47,22 +47,6 @@ export class SearchService {
    */
   public getNewListBoolean(): boolean {
     return this.newMessageListOpen;
-  }
-
-  /**
-   * Returns whether the current tagType is a channel.
-   */
-  public getChannelBoolean(): boolean | null {
-    return this.isChannel;
-  }
-
-  /**
-   * Sets the tagType to a channel.
-   *
-   * @param {boolean} isChannel - True if it should be marked as a channel, false otherwise.
-   */
-  public setChannelBoolean(boolean: boolean) {
-    this.isChannel = boolean;
   }
 
   /**
@@ -159,7 +143,7 @@ export class SearchService {
     this.textareaListOpen = false;
     this.searchInComponent === 'header' ? (this.headerListOpen = true) : (this.headerListOpen = false);
     this.searchInComponent === 'newMessage' ? (this.newMessageListOpen = true) : (this.newMessageListOpen = false);
-    this.isChannel = null;
+    this.isChannel.set(null);
   }
 
   /**
@@ -186,7 +170,7 @@ export class SearchService {
    */
   private caseChannel() {
     let searchInput: string | null = null;
-    this.isChannel = true;
+    this.isChannel.set(true);
     searchInput = this.searchQuery.split('#')[1];
     this.currentList = this.startSearch(searchInput, 'channel');
 
@@ -199,7 +183,7 @@ export class SearchService {
    */
   private caseUser() {
     let searchInput: string | null = null;
-    this.isChannel = false;
+    this.isChannel.set(false);
     searchInput = this.searchQuery.split('@')[1];
     this.currentList = this.startSearch(searchInput, 'user');
 
@@ -212,7 +196,7 @@ export class SearchService {
    */
   public resetList() {
     this.currentList = [];
-    this.isChannel = false;
+    this.isChannel.set(false);
     this.textareaListOpen = false;
     this.headerListOpen = false;
     this.newMessageListOpen = false;
@@ -293,10 +277,10 @@ export class SearchService {
     this.directTag = true;
     if (type === '#') {
       this.currentList = this.fireService.myChannels();
-      this.isChannel = true;
+      this.isChannel.set(true);
     } else if (type === '@') {
       this.currentList = this.fireService.allUsers();
-      this.isChannel = false;
+      this.isChannel.set(false);
     }
   }
 }

--- a/src/app/shared/services/search/search.service.ts
+++ b/src/app/shared/services/search/search.service.ts
@@ -21,7 +21,7 @@ export class SearchService {
   private isResultTrue: boolean = false;
   private directTag: boolean = false;
 
-  private currentList: User[] | Channel[] = [];
+  private currentList: (User | Channel)[] = [];
   private tagType: 'channel' | 'user' | null = null;
   private searchInComponent: 'header' | 'textarea' | 'newMessage' | null = null;
   private input: string = '';
@@ -73,7 +73,7 @@ export class SearchService {
   /**
    * Returns the current autocomplete result list.
    */
-  public getCurrentList(): any[] {
+  public getCurrentList(): (User | Channel)[] {
     return this.currentList;
   }
 
@@ -114,22 +114,6 @@ export class SearchService {
    */
   public stopObserveInput(): void {
     this.setResult(true);
-  }
-
-  /**
-   * Checks if the current user is anonymous.
-   * @returns {boolean | undefined} True if anonymous, false if not, or undefined if no user is signed in.
-   */
-  private isAnonymous(): boolean | undefined {
-    return this.authService.currentUser()?.isAnonymous;
-  }
-
-  /**
-   * Retrieves the UID of the current user.
-   * @returns {string | undefined} The user ID, or undefined if no user is signed in.
-   */
-  private userId(): string | undefined {
-    return this.authService.currentUser()?.id;
   }
 
   /**
@@ -245,30 +229,31 @@ export class SearchService {
    * @param channelsToSearch - The list of channels to search within.
    * @returns {string[]} A list of matching members.
    */
-  private searchChannelMembersByName(searchInput: string, channelsToSearch: any): Channel[] {
-    let foundMembers: any[] = [];
-    channelsToSearch.forEach((channel: { data?: { member?: any[] } }) => {
-      let members = channel.data?.member || [];
-      let matchingMembers = members.filter((member: any) => member.fullname?.toLowerCase().includes(searchInput));
+  private searchChannelMembersByName(searchInput: string, channelsToSearch: Channel[]): User[] {
+    const searchLower = searchInput.toLowerCase();
+    const memberIdsInChannels = new Set<string>();
 
-      foundMembers = [...foundMembers, ...matchingMembers];
+    channelsToSearch.forEach((channel) => {
+      const members = channel?.member || [];
+      members.forEach((member: { id: string }) => {
+        const id = typeof member === 'string' ? member : member.id;
+        if (id) memberIdsInChannels.add(id);
+      });
     });
-    return foundMembers;
+    this.fireService.subAllUsers();
+    const allUsers: User[] = this.fireService.allUsers();
+
+    return allUsers.filter((user) => memberIdsInChannels.has(user.id) && user.displayName?.toLowerCase().includes(searchLower));
   }
 
   /**
    * Searches channels by name.
    * @param searchInput - The lowercase input string to search for.
    * @param channelsToSearch - The list of channels to search within.
-   * @returns {string[]} A list of matching channels.
+   * @returns {Channel[]} A list of matching channels.
    */
-  private searchChannel(searchInput: string, channelsToSearch: any) {
-    let foundChannels: any = [];
-    foundChannels = channelsToSearch.filter((channel: { data?: { name?: string } }) =>
-      channel.data?.name?.toLowerCase().includes(searchInput),
-    );
-
-    return foundChannels;
+  private searchChannel(searchInput: string, channelsToSearch: Channel[]): Channel[] {
+    return channelsToSearch.filter((channel: { name: string }) => channel.name.toLowerCase().includes(searchInput));
   }
 
   /**
@@ -277,9 +262,10 @@ export class SearchService {
    * @param searchCollection - The type of entity to search for ('channel' or 'user').
    * @returns {string[]} A list of matched results.
    */
-  public startSearch(input: string, searchCollection?: 'channel' | 'user'): Channel[] {
+  public startSearch(input: string, searchCollection?: 'channel' | 'user'): (Channel | User)[] {
+    this.fireService.subChannels();
     let searchInput = input.trim()?.toLowerCase() || '';
-    let result: Channel[] = [];
+    let result: (Channel | User)[] = [];
     const channelsToSearch = this.fireService.myChannels();
 
     if (searchCollection === 'channel') {

--- a/src/app/shared/services/search/search.service.ts
+++ b/src/app/shared/services/search/search.service.ts
@@ -187,7 +187,7 @@ export class SearchService {
         break;
 
       default:
-        this.resetList;
+        this.resetList();
         break;
     }
   }

--- a/src/app/shared/services/user/shared.service.ts
+++ b/src/app/shared/services/user/shared.service.ts
@@ -1,12 +1,22 @@
-import { Injectable } from '@angular/core';
+import { Injectable, signal } from '@angular/core';
 
 @Injectable({
   providedIn: 'root',
 })
 export class UserService {
-  constructor() {}
+  public readonly feedbackMessage = signal<string | null>(null);
+  private feedbackTimeout?: ReturnType<typeof setTimeout>;
 
-  showFeedback(a: any) {}
+  /**
+   * Shows a short-lived feedback message (rendered by MainChatComponent).
+   * @param message - The message to display.
+   */
+  showFeedback(message: string): void {
+    clearTimeout(this.feedbackTimeout);
+    this.feedbackMessage.set(message);
+    this.feedbackTimeout = setTimeout(() => this.feedbackMessage.set(null), 2000);
+  }
+
   /**
    * Scrolls the chat content area to the bottom.
    */

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -360,33 +360,6 @@ textarea {
   }
 }
 
-.profile-status {
-  position: relative;
-  display: inline-flex;
-
-  &__image {
-    width: 50px;
-    height: 50px;
-    border-radius: 50%;
-    object-fit: cover;
-  }
-
-  &__dot {
-    position: absolute;
-    bottom: 0;
-    right: -4px;
-    width: 14px;
-    height: 14px;
-    border-radius: 50%;
-    border: 2px solid #ffffff;
-    background-color: var(--offline);
-
-    &--online {
-      background-color: var(--online);
-    }
-  }
-}
-
 @keyframes slide-in-r-l {
   0% {
     transform: translate(10px, 10px);


### PR DESCRIPTION
Setzt **Phase 1 der [Refactoring-Roadmap](../blob/refactor/phase-1-quickfixes/REFACTORING.md)** um — jeder Fix als eigener Commit:

- **Fix 0** `9c03373` — Build-Fehler: Null-Guard für `currentChannel()` im add-member-Template
- **Fix 1** `b4dc0ba` — fehlerhaften `@Injectable`-Decorator aus `NewmessageComponent` entfernt
- **Fix 2** `b39fcca` — `this.resetList;` → `this.resetList();` in `search.service.ts`
- **Fix 3** `65d3632`…`7c1e294` — Feld-Mismatch behoben: Queries/Zugriffe nutzen `displayName`/`id` gemäß User-Model; Empfänger-Auswahl in „Neue Nachricht" nutzt `element.id` statt nicht existentem `element.key`/`element.data`
- **Fix 4** `e94205d` — toten `getThread()`-Listener (auskommentierter Callback, kein Unsubscribe, keine Aufrufer) aus chat-channel entfernt
- **Fix 5** `279c249` — Kontakt-E-Mail aus `MessagesService` nach `shared/constants.ts` verschoben (Legal-Seiten injizieren keinen Chat-Service mehr); Debug-`console.log`s entfernt
- **Fix 6** `1da9295` — `UserService.showFeedback()` war ein leerer Stub: jetzt signal-basierter Toast, gerendert in `MainChatComponent`; alle Channel-Dialoge zeigen ihr Feedback wieder an
- Zusätzlich `988607f` — `SearchService.isChannel` als `signal<boolean | null>` (Angular-Signals statt Getter/Setter-Paar)

**Verifikation:** `ng build` nach jedem Commit grün. Manuelle Smoke-Tests gemäß Roadmap-Checkliste empfohlen (Reaktion-Hover-Namen, Mention-Klick, Neue Nachricht an Channel).

