### PR TITLE
Phase 3: Memory Leaks & Subscription-Hygiene

### DIFF
--- a/src/app/features/app_auth/components/reset-password/reset-password.component.ts
+++ b/src/app/features/app_auth/components/reset-password/reset-password.component.ts
@@ -44,9 +44,7 @@ export class ResetpasswordComponent implements OnInit {
    */
   ngOnInit() {
     this.auth = getAuth(this.afApp);
-    this.activatedRoute.queryParams.subscribe((params) => {
-      this.resetCode = params['oobCode'] || '';
-    });
+    this.resetCode = this.activatedRoute.snapshot.queryParamMap.get('oobCode') || '';
     verifyPasswordResetCode(this.auth, this.resetCode)
       .then((email) => {
         this.email = email;

--- a/src/app/features/app_auth/services/auth/auth.service.ts
+++ b/src/app/features/app_auth/services/auth/auth.service.ts
@@ -32,6 +32,7 @@ export class AuthService {
 
   private _currentUser = signal<User | null>(null);
   public currentUser = this._currentUser.asReadonly();
+  private unsubUserDoc?: () => void;
 
   constructor() {
     this.setCurrentUser();
@@ -218,12 +219,15 @@ export class AuthService {
    */
   setCurrentUser() {
     onAuthStateChanged(this.auth, (firebaseUser) => {
+      this.unsubUserDoc?.();
+      this.unsubUserDoc = undefined;
+
       if (firebaseUser) {
         this._currentUser.set(this.mapFirebaseUserToUser(firebaseUser));
 
         const userDocRef = doc(this.firestore, `users/${firebaseUser.uid}`);
 
-        onSnapshot(userDocRef, (docSnap) => {
+        this.unsubUserDoc = onSnapshot(userDocRef, (docSnap) => {
           if (docSnap.exists()) {
             const firestoreData = docSnap.data() as User;
             this._currentUser.set(firestoreData);

--- a/src/app/features/app_chat/components/chat-channel/chat-channel.component.ts
+++ b/src/app/features/app_chat/components/chat-channel/chat-channel.component.ts
@@ -73,6 +73,7 @@ export class ChatContentComponent implements OnInit, OnDestroy {
       const channelId = this.currentChannelId();
       untracked(() => {
         if (this.unsubChannelData) this.unsubChannelData();
+        this.unsubMessages?.();
         if (channelId) {
           this.unsubMessages = this.messagesService.subToMessages(channelId);
           this.getCurrentChannelData(channelId);

--- a/src/app/features/app_chat/components/chat-channel/chat-channel.component.ts
+++ b/src/app/features/app_chat/components/chat-channel/chat-channel.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
-import { Component, ElementRef, inject, OnInit, ViewChild, OnDestroy, untracked, effect, signal } from '@angular/core';
+import { Component, ElementRef, inject, OnInit, ViewChild, OnDestroy, untracked, effect, signal, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -48,6 +49,7 @@ export class ChatContentComponent implements OnInit, OnDestroy {
   messagesService: MessagesService = inject(MessagesService);
   route: ActivatedRoute = inject(ActivatedRoute);
   public chatService: ChatService = inject(ChatService);
+  private readonly destroyRef = inject(DestroyRef);
 
   isMobile: boolean = false;
   showBackground: boolean = false;
@@ -93,7 +95,7 @@ export class ChatContentComponent implements OnInit, OnDestroy {
    * Initializes the component, loads messages and channel data from URL parameters.
    */
   async ngOnInit() {
-    this.route.paramMap.subscribe((params) => {
+    this.route.paramMap.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params) => {
       this.currentChannelId.set(params.get('id'));
     });
   }

--- a/src/app/features/app_chat/components/chat-direct/chat-direct.component.ts
+++ b/src/app/features/app_chat/components/chat-direct/chat-direct.component.ts
@@ -1,4 +1,5 @@
-import { Component, inject, OnInit, ElementRef, ViewChild, OnDestroy, signal, computed } from '@angular/core';
+import { Component, inject, OnInit, ElementRef, ViewChild, OnDestroy, signal, computed, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { getDoc } from '@angular/fire/firestore';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
@@ -46,6 +47,7 @@ export class DirectmessagesComponent implements OnInit, OnDestroy {
   private readonly dialog = inject(MatDialog);
   public messagesService = inject(MessagesService);
   public chatService: ChatService = inject(ChatService);
+  private readonly destroyRef = inject(DestroyRef);
 
   public currentRecieverId = signal<string | null>(null);
   public currentReciever = signal<User | null>(null);
@@ -55,7 +57,7 @@ export class DirectmessagesComponent implements OnInit, OnDestroy {
    * Initializes the component and loads the necessary data such as receiver information, messages, users, and channels.
    */
   ngOnInit() {
-    this.route.paramMap.subscribe((params) => {
+    this.route.paramMap.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params) => {
       this.currentRecieverId.set(params.get('id'));
       this.getRecieverFromUrl();
       this.loadDirectChat(this.currentRecieverId() || '');

--- a/src/app/features/app_chat/components/chat-thread/chat-thread.component.ts
+++ b/src/app/features/app_chat/components/chat-thread/chat-thread.component.ts
@@ -1,6 +1,7 @@
-import { Component, ElementRef, inject, OnInit, ViewChild } from '@angular/core';
+import { Component, DestroyRef, ElementRef, inject, OnInit, ViewChild } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { Firestore, collection, doc, getDoc, getDocs, onSnapshot, orderBy, query, where } from '@angular/fire/firestore';
 import { MatIconModule } from '@angular/material/icon';
@@ -36,6 +37,7 @@ export class ThreadComponent implements OnInit {
   public userService: UserService = inject(UserService);
   public authService = inject(AuthService);
   public navigationService: NavigationService = inject(NavigationService);
+  private readonly destroyRef = inject(DestroyRef);
   public currentUser: any;
   public userId: string = '';
   public currentChannel: any;
@@ -54,13 +56,13 @@ export class ThreadComponent implements OnInit {
    *
    * @type {() => void}
    */
-  unsubMessages!: () => void;
+  unsubMessages?: () => void;
 
   /**
    * OnInit lifecycle hook to set up query params and fetch data when component is initialized.
    */
   async ngOnInit() {
-    this.route.queryParams.subscribe(async (params) => {
+    this.route.queryParams.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(async (params) => {
       this.currentChannelId = params['reciverId'] || '';
       this.userId = params['currentUserId'] || '';
       this.parentMessageId = params['messageId'] || '';
@@ -118,14 +120,18 @@ export class ThreadComponent implements OnInit {
    * Retrieves the messages in the current thread.
    */
   private getMessages() {
+    this.unsubMessages?.();
+    this.unsubMessages = undefined;
+
     if (this.parentMessageId) {
       let threadRef = collection(this.firestore, `channels/${this.currentChannelId}/messages/${this.parentMessageId}/thread`);
       let threadQuery = query(threadRef, orderBy('timestamp', 'asc'));
 
-      onSnapshot(threadQuery, (snapshot) => {
+      this.unsubMessages = onSnapshot(threadQuery, (snapshot) => {
         this.messages = this.messagesService.processData(snapshot);
-        // this.userService.scrollToBottom(this.chatContentRef.nativeElement);
       });
+    } else {
+      this.messages = [];
     }
   }
 

--- a/src/app/features/app_chat/components/contactbar/contactbar.component.ts
+++ b/src/app/features/app_chat/components/contactbar/contactbar.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, inject, OnDestroy, OnInit } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
@@ -22,7 +22,7 @@ import { ProfileStatusComponent } from '../../../../shared/components/profile-st
   templateUrl: './contactbar.component.html',
   styleUrl: './contactbar.component.scss',
 })
-export class ContactbarComponent implements OnInit, OnDestroy {
+export class ContactbarComponent implements OnInit {
   public firestoreService = inject(FireServiceService);
   public navigationService: NavigationService = inject(NavigationService);
   public searchService: SearchService = inject(SearchService);
@@ -37,15 +37,13 @@ export class ContactbarComponent implements OnInit, OnDestroy {
   public currentLink: string = '';
   public addChannelWindow: boolean = false;
 
-  private unsubUsers?: any;
-  private unsubChannels?: any;
-
   /**
-   * Initializes the component by loading users, channels, and setting the current user.
+   * Initializes the component by ensuring the shared user and channel
+   * streams are running (owned by FireService, app-lifetime).
    */
-  async ngOnInit() {
-    this.unsubUsers = this.firestoreService.subAllUsers();
-    this.unsubChannels = this.firestoreService.subChannels();
+  ngOnInit() {
+    this.firestoreService.subAllUsers();
+    this.firestoreService.subChannels();
   }
 
   public toggleDropdown(type: 'channels' | 'directMessages') {
@@ -69,8 +67,4 @@ export class ContactbarComponent implements OnInit, OnDestroy {
     });
   }
 
-  ngOnDestroy() {
-    if (this.unsubUsers) this.unsubUsers();
-    if (this.unsubChannels) this.unsubChannels();
-  }
 }

--- a/src/app/shared/services/firebase/fire-service.service.ts
+++ b/src/app/shared/services/firebase/fire-service.service.ts
@@ -27,6 +27,8 @@ export class FireServiceService {
   private injector = inject(Injector);
   public allUsers = signal<User[]>([]);
   private _allChannels = signal<any[]>([]);
+  private unsubAllUsers?: () => void;
+  private unsubChannels?: () => void;
 
   /**
    * Updates the online status of the current user in Firestore.
@@ -45,11 +47,14 @@ export class FireServiceService {
   /**
    * Erstellt eine permanente Verbindung zur User-Collection.
    * Jede Änderung (Login/Logout/Neuer User) triggert das Signal sofort.
+   * Idempotent: der Listener lebt für die App-Lebensdauer, weitere Aufrufe
+   * sind No-ops (vorher entstand pro Aufruf ein neuer Listener).
    */
-  public subAllUsers() {
+  public subAllUsers(): void {
+    if (this.unsubAllUsers) return;
     const usersCollection = collection(this.firestore, 'users');
 
-    return onSnapshot(
+    this.unsubAllUsers = onSnapshot(
       usersCollection,
       (snapshot) => {
         const users = snapshot.docs.map(
@@ -68,12 +73,14 @@ export class FireServiceService {
   }
 
   /**
-   * Startet den Echtzeit-Stream für alle Channels
+   * Startet den Echtzeit-Stream für alle Channels.
+   * Idempotent wie subAllUsers().
    */
-  public subChannels() {
+  public subChannels(): void {
+    if (this.unsubChannels) return;
     const channelRef = collection(this.firestore, 'channels');
 
-    return onSnapshot(channelRef, (snapshot) => {
+    this.unsubChannels = onSnapshot(channelRef, (snapshot) => {
       const data = snapshot.docs.map((doc) => ({
         id: doc.id,
         ...doc.data(),

--- a/src/core/auth.guard.ts
+++ b/src/core/auth.guard.ts
@@ -4,9 +4,11 @@ import { CanActivateFn, Router } from '@angular/router';
 
 export const authGuard: CanActivateFn = (route, state) => {
   const router = inject(Router);
+  const auth = inject(Auth);
 
   return new Promise((resolve) => {
-    onAuthStateChanged(inject(Auth), (user) => {
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      unsubscribe();
       if (user) {
         resolve(true);
       } else {


### PR DESCRIPTION
Setzt **Phase 3 der Refactoring-Roadmap** um (stacked auf #14; Merge-Reihenfolge #11 → #14 → dieser PR).

### Fixes (je 1 Commit)
- **auth.service**: verschachteltes `onSnapshot` aufs User-Dokument wird bei jedem Auth-Wechsel abgemeldet (vorher Re-Subscribe-Leak bei Logout→Login)
- **Route-Subscriptions**: `takeUntilDestroyed(DestroyRef)` für `paramMap`/`queryParams` in chat-channel, chat-direct, chat-thread
- **chat-thread**: `onSnapshot`-Rückgabe wird dem deklarierten `unsubMessages` zugewiesen; alter Listener wird vor jedem Re-Subscribe abgemeldet; Thread-Schließen leert die Message-Liste
- **FireService**: `subAllUsers()`/`subChannels()` sind jetzt idempotente App-Lifetime-Streams — vorher entstand **pro Aufruf** ein neuer Firestore-Listener, u. a. bei **jedem Such-Tastendruck** über den SearchService; contactbar meldet die geteilten Streams nicht mehr ab
- **authGuard**: gab bei jeder Navigation einen permanenten `onAuthStateChanged`-Listener in Auftrag → wird nach der ersten Emission abgemeldet
- **reset-password**: `oobCode` aus dem Route-Snapshot statt unmanaged Subscription
- **chat-channel**: Messages-Listener wird beim Channel-Wechsel abgemeldet (vorher potenziell doppelt gerenderte Nachrichten)

### Verifikation
`ng build` grün nach jedem Commit. Smoke-Test: 10× Channel-Wechsel, Thread mehrfach öffnen/schließen, Logout/Login → gesendete Nachricht erscheint genau 1×.

🤖 Generated with [Claude Code](https://claude.com/claude-code)