### PR TITLE
Phase 4: Single Source of Truth „aktiver Channel" + DI-Zyklus auflösen

### DIFF
--- a/src/app/features/app_auth/services/auth/auth.service.ts
+++ b/src/app/features/app_auth/services/auth/auth.service.ts
@@ -9,6 +9,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 
 import { NavigationService } from '../../../../shared/services/navigation/navigation.service';
 import { FireServiceService } from '../../../../shared/services/firebase/fire-service.service';
+import { UserStore } from '../../../../shared/services/user/user-store';
 import { RegisterData, User } from '../../models/user/user';
 import { DEFAULT_CHANNEL_ID, GUEST_EMAIL } from '../../../../shared/constants';
 
@@ -31,8 +32,8 @@ export class AuthService {
   private readonly passwordPattern = '^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).{6,}$';
   private tempUserData = signal<RegisterData | null>(null);
 
-  private _currentUser = signal<User | null>(null);
-  public currentUser = this._currentUser.asReadonly();
+  private userStore = inject(UserStore);
+  public currentUser = this.userStore.currentUser;
   private unsubUserDoc?: () => void;
 
   constructor() {
@@ -223,18 +224,18 @@ export class AuthService {
       this.unsubUserDoc = undefined;
 
       if (firebaseUser) {
-        this._currentUser.set(this.mapFirebaseUserToUser(firebaseUser));
+        this.userStore.setCurrentUser(this.mapFirebaseUserToUser(firebaseUser));
 
         const userDocRef = doc(this.firestore, `users/${firebaseUser.uid}`);
 
         this.unsubUserDoc = onSnapshot(userDocRef, (docSnap) => {
           if (docSnap.exists()) {
             const firestoreData = docSnap.data() as User;
-            this._currentUser.set(firestoreData);
+            this.userStore.setCurrentUser(firestoreData);
           }
         });
       } else {
-        this._currentUser.set(null);
+        this.userStore.setCurrentUser(null);
       }
     });
   }

--- a/src/app/features/app_auth/services/auth/auth.service.ts
+++ b/src/app/features/app_auth/services/auth/auth.service.ts
@@ -10,6 +10,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { NavigationService } from '../../../../shared/services/navigation/navigation.service';
 import { FireServiceService } from '../../../../shared/services/firebase/fire-service.service';
 import { RegisterData, User } from '../../models/user/user';
+import { DEFAULT_CHANNEL_ID, GUEST_EMAIL } from '../../../../shared/constants';
 
 @Injectable({
   providedIn: 'root',
@@ -109,7 +110,7 @@ export class AuthService {
    * @param user - The user to be added to the default channel
    */
   private async addInDefaultChannel(user: User) {
-    const defaultChannelRef = doc(this.firestore, `channels/KqvcY68R1jP2UsQkv6Nz`);
+    const defaultChannelRef = doc(this.firestore, `channels/${DEFAULT_CHANNEL_ID}`);
     try {
       await updateDoc(defaultChannelRef, {
         member: arrayUnion({
@@ -178,7 +179,6 @@ export class AuthService {
    */
   public async loginAsGuest() {
     this.isLoading = true;
-    const GUEST_EMAIL = 'gast@portfolio.de';
     const GUEST_PW = 'Gast1234';
 
     try {

--- a/src/app/features/app_channel/components/add-member/add-member.component.ts
+++ b/src/app/features/app_channel/components/add-member/add-member.component.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component, inject, signal } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 
 import { DialogReciverComponent } from '../../../dialogs/dialog-reciver/dialog-reciver.component';
 import { AuthService } from '../../../app_auth/services/auth/auth.service';
@@ -22,7 +22,6 @@ export class AddMemberComponent {
   private readonly dialog = inject(MatDialog);
 
   public readonly dialogRef = inject(MatDialogRef<AddMemberComponent>);
-  public readonly data = inject<any>(MAT_DIALOG_DATA);
 
   showUserBar: boolean = false;
   addMemberWindow: boolean = false;
@@ -30,7 +29,6 @@ export class AddMemberComponent {
   public isSubmiting = signal<boolean>(false);
 
   constructor() {
-    this.channelService.currentChannel.set(this.data);
     this.channelService.allMembersSelected.set(false);
     this.channelService.resetSelection();
   }

--- a/src/app/features/app_channel/components/edit.channel/edit.channel.component.ts
+++ b/src/app/features/app_channel/components/edit.channel/edit.channel.component.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component, inject, computed, signal } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { UserService } from '../../../../shared/services/user/shared.service';
 import { NavigationService } from '../../../../shared/services/navigation/navigation.service';
 import { DialogReciverComponent } from '../../../dialogs/dialog-reciver/dialog-reciver.component';
@@ -8,7 +8,6 @@ import { User } from '../../../app_auth/models/user/user';
 import { MatIcon } from '@angular/material/icon';
 import { FormsModule } from '@angular/forms';
 import { ChannelService } from '../../services/channel/channel.service';
-import { Channel } from '../../models/channel/channel';
 import { ProfileStatusComponent } from '../../../../shared/components/profile-status/profile-status.component';
 
 @Component({
@@ -23,7 +22,6 @@ export class EditChannelComponent {
   private readonly dialog = inject(MatDialog);
   private readonly dialogRef: MatDialogRef<EditChannelComponent> = inject(MatDialogRef<EditChannelComponent>);
   public readonly channelService = inject(ChannelService);
-  public readonly data = inject<Channel>(MAT_DIALOG_DATA);
 
   public channelNameEdit: boolean = false;
   public channelDescriptionEdit: boolean = false;
@@ -33,7 +31,6 @@ export class EditChannelComponent {
   public showUserBar: boolean = false;
 
   constructor() {
-    this.channelService.currentChannel.set(this.data);
     this.channelService.allMembersSelected.set(false);
     this.channelService.resetSelection();
   }

--- a/src/app/features/app_channel/services/channel/channel.service.ts
+++ b/src/app/features/app_channel/services/channel/channel.service.ts
@@ -1,4 +1,5 @@
 import { computed, inject, Injectable, signal } from '@angular/core';
+import { onSnapshot } from '@angular/fire/firestore';
 import { FireServiceService } from '../../../../shared/services/firebase/fire-service.service';
 import { User } from '../../../app_auth/models/user/user';
 import { AuthService } from '../../../app_auth/services/auth/auth.service';
@@ -16,6 +17,7 @@ export class ChannelService {
   private readonly authService = inject(AuthService);
 
   public currentChannel = signal<Channel | null>(null);
+  private unsubCurrentChannel?: () => void;
   public selectedUsers = signal<User[]>([]);
   public userSearchQuery = signal('');
   public allMembersSelected = signal<boolean>(false);
@@ -87,6 +89,28 @@ export class ChannelService {
   });
 
   private isSubmitting = signal<boolean>(false);
+
+  /**
+   * Single source of truth for the active channel: holds THE one
+   * Firestore listener on the channel document (derived from the route
+   * param) and feeds the currentChannel signal. Passing null clears it.
+   */
+  public setActiveChannel(id: string | null): void {
+    this.unsubCurrentChannel?.();
+    this.unsubCurrentChannel = undefined;
+
+    if (!id) {
+      this.currentChannel.set(null);
+      return;
+    }
+
+    const channelRef = this.fireService.getDocRef('channels', id);
+    if (!channelRef) return;
+
+    this.unsubCurrentChannel = onSnapshot(channelRef, (snap) => {
+      this.currentChannel.set(snap.exists() ? ({ id: snap.id, ...snap.data() } as Channel) : null);
+    });
+  }
 
   async createChannel(channelData: Channel) {
     try {

--- a/src/app/features/app_channel/services/channel/channel.service.ts
+++ b/src/app/features/app_channel/services/channel/channel.service.ts
@@ -151,12 +151,10 @@ export class ChannelService {
 
   public async updateName(id: string, name: string) {
     await this.fireService.updateChannelData(id, { name });
-    this.currentChannel.update((c) => ({ ...c, name }) as Channel);
   }
 
   public async updateDescription(id: string, description: string) {
     await this.fireService.updateChannelData(id, { description });
-    this.currentChannel.update((c) => ({ ...c, description }) as Channel);
   }
 
   public async addMembers(id: string, userObjects: { id: string }[]) {
@@ -166,19 +164,6 @@ export class ChannelService {
       this.isSubmitting.set(true);
 
       await this.fireService.addChannelMembers(id, userObjects);
-
-      this.currentChannel.update((current) => {
-        if (!current) return null;
-
-        const existingIds = new Set((current.member || []).map((m: any) => m.id));
-        const newUniqueMembers = userObjects.filter((obj) => !existingIds.has(obj.id));
-
-        return {
-          ...current,
-          member: [...(current.member || []), ...newUniqueMembers],
-        } as Channel;
-      });
-
       this.resetSelection();
     } catch (error) {
       console.error('Fehler beim Hinzufügen der Mitglieder:', error);

--- a/src/app/features/app_chat/components/chat-channel/chat-channel.component.html
+++ b/src/app/features/app_chat/components/chat-channel/chat-channel.component.html
@@ -7,7 +7,7 @@
     <section class="card-header">
       <div class="tooltip-cont">
         <div class="addChannel" class="align-center hover-bg cursor-pointer" (click)="openChannelInfo()">
-          # {{ this.currentChannel?.name }}
+          # {{ channelService.currentChannel()?.name }}
           <mat-icon fontIcon="keyboard_arrow_down"></mat-icon>
         </div>
         <span class="tooltip guest-msg-pos">Zugang für Gäste gesperrt</span>
@@ -17,12 +17,12 @@
         <div class="tooltip-cont">
           <div class="avatar-container hover-bg" (click)="openMemberWindow(false)">
             <div class="member-img-cont">
-              @for (member of currentChannel?.member; track $index; let i = $index) {
-                <img *ngIf="i < 3" class="avatar" [src]="member.photoURL" alt="Name" />
+              @for (member of channelService.currentChannel()?.member; track $index; let i = $index) {
+                <img *ngIf="i < 3" class="avatar" [src]="$any(member).photoURL" alt="Name" />
               }
             </div>
-            @if (currentChannel?.member?.length) {
-              <span>{{ currentChannel?.member?.length }}</span>
+            @if (channelService.currentChannel()?.member?.length) {
+              <span>{{ channelService.currentChannel()?.member?.length }}</span>
             }
           </div>
 
@@ -68,11 +68,11 @@
     <section class="card-footer">
       <app-textarea-template
         [reciverId]="currentChannelId() || ''"
-        [reciverName]="currentChannel?.name"
+        [reciverName]="channelService.currentChannel()?.name || ''"
         [reciverCompontent]="'channel'"
         [messages]="this.messagesService.messages()"
         [isChannelComponent]="true"
-        [placeholderText]="'Nachricht an #' + currentChannel?.name"
+        [placeholderText]="'Nachricht an #' + (channelService.currentChannel()?.name || '')"
       ></app-textarea-template>
     </section>
   </div>

--- a/src/app/features/app_chat/components/chat-channel/chat-channel.component.ts
+++ b/src/app/features/app_chat/components/chat-channel/chat-channel.component.ts
@@ -4,7 +4,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
-import { Firestore, onSnapshot, doc } from '@angular/fire/firestore';
+import { ChannelService } from '../../../app_channel/services/channel/channel.service';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { ActivatedRoute } from '@angular/router';
 import { MatMenuModule } from '@angular/material/menu';
@@ -43,7 +43,7 @@ export class ChatContentComponent implements OnInit, OnDestroy {
   @ViewChild('chatContent') chatContentRef!: ElementRef;
   fireService: FireServiceService = inject(FireServiceService);
   userService: UserService = inject(UserService);
-  firestore: Firestore = inject(Firestore);
+  channelService: ChannelService = inject(ChannelService);
   dialog = inject(MatDialog);
   navigationService: NavigationService = inject(NavigationService);
   messagesService: MessagesService = inject(MessagesService);
@@ -55,7 +55,6 @@ export class ChatContentComponent implements OnInit, OnDestroy {
   showBackground: boolean = false;
   channels: any = [];
 
-  currentChannel: any = {};
   channelInfo: boolean = false;
   addMemberInfoWindow: boolean = false;
   addMemberWindow: boolean = false;
@@ -65,19 +64,18 @@ export class ChatContentComponent implements OnInit, OnDestroy {
 
   public currentChannelId = signal<string | null>(null);
 
-  unsubChannelData!: () => void;
   unsubMessages?: () => void;
 
   constructor() {
     effect(() => {
       const channelId = this.currentChannelId();
       untracked(() => {
-        if (this.unsubChannelData) this.unsubChannelData();
         this.unsubMessages?.();
+        this.unsubMessages = undefined;
         if (channelId) {
           this.unsubMessages = this.messagesService.subToMessages(channelId);
-          this.getCurrentChannelData(channelId);
         }
+        this.channelService.setActiveChannel(channelId);
       });
     });
 
@@ -114,27 +112,11 @@ export class ChatContentComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Loads the current channel from Firestore based on the channel ID.
-   */
-  private getCurrentChannelData(channelId: string | null) {
-    if (this.unsubChannelData) this.unsubChannelData();
-
-    if (channelId) {
-      const docRef = doc(this.firestore, 'channels', channelId);
-      this.unsubChannelData = onSnapshot(docRef, (docSnap) => {
-        if (docSnap.exists()) {
-          this.currentChannel = { id: docSnap.id, ...docSnap.data() };
-        }
-      });
-    }
-  }
-
-  /**
    * Opens the dialog to view or edit channel information.
    */
   openChannelInfo() {
     this.dialog.open(EditChannelComponent, {
-      data: this.currentChannel,
+      data: this.channelService.currentChannel(),
       position: { top: '200px' },
       width: '872px',
       maxWidth: '95vw',
@@ -151,7 +133,7 @@ export class ChatContentComponent implements OnInit, OnDestroy {
     this.addMemberWindow = toggle;
 
     this.dialog.open(AddMemberComponent, {
-      data: this.currentChannel,
+      data: this.channelService.currentChannel(),
       width: 'auto',
       maxWidth: '95vw',
       maxHeight: '90vh',
@@ -165,8 +147,8 @@ export class ChatContentComponent implements OnInit, OnDestroy {
    * Cleans up subscriptions and listeners when the component is destroyed.
    */
   ngOnDestroy() {
-    if (this.unsubChannelData) this.unsubChannelData();
     if (this.unsubMessages) this.unsubMessages();
     this.messagesService.messages.set([]);
+    this.channelService.setActiveChannel(null);
   }
 }

--- a/src/app/features/app_chat/components/chat-channel/chat-channel.component.ts
+++ b/src/app/features/app_chat/components/chat-channel/chat-channel.component.ts
@@ -116,7 +116,6 @@ export class ChatContentComponent implements OnInit, OnDestroy {
    */
   openChannelInfo() {
     this.dialog.open(EditChannelComponent, {
-      data: this.channelService.currentChannel(),
       position: { top: '200px' },
       width: '872px',
       maxWidth: '95vw',
@@ -133,7 +132,6 @@ export class ChatContentComponent implements OnInit, OnDestroy {
     this.addMemberWindow = toggle;
 
     this.dialog.open(AddMemberComponent, {
-      data: this.channelService.currentChannel(),
       width: 'auto',
       maxWidth: '95vw',
       maxHeight: '90vh',

--- a/src/app/shared/constants.ts
+++ b/src/app/shared/constants.ts
@@ -1,1 +1,5 @@
 export const CONTACT_EMAIL = 'gianniskarakasidhs@hotmail.com';
+
+export const DEFAULT_CHANNEL_ID = 'KqvcY68R1jP2UsQkv6Nz';
+
+export const GUEST_EMAIL = 'gast@portfolio.de';

--- a/src/app/shared/services/firebase/fire-service.service.ts
+++ b/src/app/shared/services/firebase/fire-service.service.ts
@@ -18,6 +18,7 @@ import { ChannelMessage } from '../../../features/app_chat/models/channel-messag
 import { User } from '../../../features/app_auth/models/user/user';
 import { Channel } from '../../../features/app_channel/models/channel/channel';
 import { AuthService } from '../../../features/app_auth/services/auth/auth.service';
+import { DEFAULT_CHANNEL_ID, GUEST_EMAIL } from '../../constants';
 
 @Injectable({
   providedIn: 'root',
@@ -93,11 +94,10 @@ export class FireServiceService {
     const authService = this.injector.get(AuthService);
     const channels: Channel[] = this._allChannels();
     const currentUser = authService.currentUser();
-    const DEFAULT_CHANNEL_ID = 'KqvcY68R1jP2UsQkv6Nz';
 
     if (!currentUser) return [];
 
-    const isGuest = currentUser.email === 'gast@portfolio.de';
+    const isGuest = currentUser.email === GUEST_EMAIL;
     return channels.filter((channel) => {
       if (isGuest) {
         return channel.id === DEFAULT_CHANNEL_ID || channel.createdBy === currentUser.id;

--- a/src/app/shared/services/firebase/fire-service.service.ts
+++ b/src/app/shared/services/firebase/fire-service.service.ts
@@ -1,4 +1,4 @@
-import { computed, inject, Injectable, Injector, signal } from '@angular/core';
+import { computed, inject, Injectable, signal } from '@angular/core';
 import {
   addDoc,
   arrayRemove,
@@ -17,15 +17,15 @@ import {
 import { ChannelMessage } from '../../../features/app_chat/models/channel-message/channel-message';
 import { User } from '../../../features/app_auth/models/user/user';
 import { Channel } from '../../../features/app_channel/models/channel/channel';
-import { AuthService } from '../../../features/app_auth/services/auth/auth.service';
 import { DEFAULT_CHANNEL_ID, GUEST_EMAIL } from '../../constants';
+import { UserStore } from '../user/user-store';
 
 @Injectable({
   providedIn: 'root',
 })
 export class FireServiceService {
   private firestore: Firestore = inject(Firestore);
-  private injector = inject(Injector);
+  private userStore = inject(UserStore);
   public allUsers = signal<User[]>([]);
   private _allChannels = signal<any[]>([]);
   private unsubAllUsers?: () => void;
@@ -91,9 +91,8 @@ export class FireServiceService {
   }
 
   public myChannels = computed(() => {
-    const authService = this.injector.get(AuthService);
     const channels: Channel[] = this._allChannels();
-    const currentUser = authService.currentUser();
+    const currentUser = this.userStore.currentUser();
 
     if (!currentUser) return [];
 

--- a/src/app/shared/services/user/user-store.ts
+++ b/src/app/shared/services/user/user-store.ts
@@ -1,0 +1,19 @@
+import { Injectable, signal } from '@angular/core';
+import { User } from '../../../features/app_auth/models/user/user';
+
+/**
+ * Holds the authenticated user's data. AuthService writes to it,
+ * everyone else (FireService, components) reads the signal — this
+ * breaks the former FireService <-> AuthService injection cycle.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class UserStore {
+  private readonly _currentUser = signal<User | null>(null);
+  public readonly currentUser = this._currentUser.asReadonly();
+
+  public setCurrentUser(user: User | null): void {
+    this._currentUser.set(user);
+  }
+}


### PR DESCRIPTION
Setzt **Phase 4 der Refactoring-Roadmap** um (stacked auf #15; Merge-Reihenfolge #11 → #14 → #15 → dieser PR). Strikt in Roadmap-Reihenfolge, je 1 Commit:

1. **Konstanten**: `DEFAULT_CHANNEL_ID` und `GUEST_EMAIL` nach `shared/constants.ts` (Magic Strings waren in auth.service + fire-service dupliziert)
2. **`ChannelService.setActiveChannel(id)`**: Der Service hält das EINE `onSnapshot` aufs Channel-Dokument (getrieben vom Route-Param) und exponiert `currentChannel` als Signal. Das komponenten-eigene Snapshot in chat-channel entfällt, ebenso deren `Firestore`-Inject; Verlassen der Route setzt den aktiven Channel zurück
3. **Leser umgestellt**: edit-channel und add-member seeden `currentChannel` nicht mehr aus `MAT_DIALOG_DATA`, sondern lesen das Live-Signal; die redundanten optimistischen Mutationen in `updateName`/`updateDescription`/`addMembers` sind entfernt → Channel-Name-Änderung aktualisiert den Header live über das Snapshot
4. **DI-Zyklus aufgelöst**: neuer `UserStore` (Signal) — AuthService schreibt, FireService liest für `myChannels`; `Injector.get(AuthService)` entfällt. `AuthService.currentUser` bleibt als Alias, Aufrufer unverändert

### Verifikation
`ng build` grün nach jedem Commit. Smoke-Test: Channel-Wechsel → Header/Liste/Dialoge konsistent; Channel-Name im Edit-Dialog ändern → Header live; Deep-Link-Reload auf `/main/channel/:id`; Member hinzufügen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)