### PR TITLE
Phase 5: Firestore raus aus den Komponenten

### DIFF
--- a/src/app/features/app_auth/components/login/login.component.ts
+++ b/src/app/features/app_auth/components/login/login.component.ts
@@ -1,12 +1,8 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { MatDividerModule } from '@angular/material/divider';
-import { Auth } from '@angular/fire/auth';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { Firestore } from '@angular/fire/firestore';
 import { MatIconModule } from '@angular/material/icon';
-import { UserService } from '../../../../shared/services/user/shared.service';
-import { FireServiceService } from '../../../../shared/services/firebase/fire-service.service';
 import { AuthService } from '../../services/auth/auth.service';
 import { NavigationService } from '../../../../shared/services/navigation/navigation.service';
 
@@ -18,10 +14,6 @@ import { NavigationService } from '../../../../shared/services/navigation/naviga
 })
 export class LoginComponent {
   disabled = true;
-  shared = inject(UserService);
-  auth = inject(Auth);
-  firestore = inject(Firestore);
-  fireService = inject(FireServiceService);
   authService: AuthService = inject(AuthService);
   navigationService: NavigationService = inject(NavigationService);
 

--- a/src/app/features/app_channel/services/channel/channel.service.ts
+++ b/src/app/features/app_channel/services/channel/channel.service.ts
@@ -1,5 +1,5 @@
 import { computed, inject, Injectable, signal } from '@angular/core';
-import { onSnapshot } from '@angular/fire/firestore';
+import { getDocs, onSnapshot, query, where } from '@angular/fire/firestore';
 import { FireServiceService } from '../../../../shared/services/firebase/fire-service.service';
 import { User } from '../../../app_auth/models/user/user';
 import { AuthService } from '../../../app_auth/services/auth/auth.service';
@@ -171,6 +171,19 @@ export class ChannelService {
     } finally {
       this.isSubmitting.set(false);
     }
+  }
+
+  /**
+   * Looks up a channel document by its name (used for #mentions).
+   */
+  public async findChannelByName(name: string): Promise<Channel | null> {
+    const channelsRef = this.fireService.getCollectionRef('channels');
+    if (!channelsRef) return null;
+
+    const q = query(channelsRef, where('name', '==', name.trim()));
+    const snapshot = await getDocs(q);
+    const docSnap = snapshot.docs[0];
+    return docSnap ? ({ id: docSnap.id, ...docSnap.data() } as Channel) : null;
   }
 
   public async leaveChannel() {

--- a/src/app/features/app_chat/components/chat-direct/chat-direct.component.ts
+++ b/src/app/features/app_chat/components/chat-direct/chat-direct.component.ts
@@ -1,6 +1,5 @@
 import { Component, inject, OnInit, ElementRef, ViewChild, OnDestroy, signal, computed, DestroyRef } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { getDoc } from '@angular/fire/firestore';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
@@ -12,7 +11,7 @@ import { DividerTemplateComponent } from '../divider/divider-template.component'
 import { MessageTemplateComponent } from '../message/message-template.component';
 import { UserService } from '../../../../shared/services/user/shared.service';
 import { NavigationService } from '../../../../shared/services/navigation/navigation.service';
-import { FireServiceService } from '../../../../shared/services/firebase/fire-service.service';
+import { UserStore } from '../../../../shared/services/user/user-store';
 import { MessagesService } from '../../services/messages/messages.service';
 import { ChatHeaderComponent } from '../chat-header/chat-header.component';
 import { User } from '../../../app_auth/models/user/user';
@@ -41,7 +40,7 @@ export class DirectmessagesComponent implements OnInit, OnDestroy {
   @ViewChild('chat') chatContentRef!: ElementRef;
   public readonly userService = inject(UserService);
   public readonly navigationService = inject(NavigationService);
-  private readonly firestoreService = inject(FireServiceService);
+  private readonly userStore = inject(UserStore);
   private readonly route: ActivatedRoute = inject(ActivatedRoute);
   public readonly authService = inject(AuthService);
   private readonly dialog = inject(MatDialog);
@@ -73,19 +72,11 @@ export class DirectmessagesComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Retrieves the receiver's data from Firestore using the receiver ID.
+   * Retrieves the receiver's data using the receiver ID from the route.
    */
   private async getRecieverFromUrl() {
-    if (this.currentRecieverId) {
-      const docRef = this.firestoreService.getDocRef('users', this.currentRecieverId() || '');
-      if (docRef) {
-        const docSnap = await getDoc(docRef);
-        if (docSnap.exists()) {
-          const data = docSnap.data();
-          this.currentReciever.set({ id: docSnap.id, ...data } as User);
-        }
-      }
-    }
+    const user = await this.userStore.getUserById(this.currentRecieverId() || '');
+    if (user) this.currentReciever.set(user);
   }
 
   /**

--- a/src/app/features/app_chat/components/chat-thread/chat-thread.component.html
+++ b/src/app/features/app_chat/components/chat-thread/chat-thread.component.html
@@ -8,7 +8,7 @@
         <div class="thread-container">
           <p>Thread</p>
         </div>
-        <div class="channel-name-container"># {{ currentChannel?.name }}</div>
+        <div class="channel-name-container"># {{ channelService.currentChannel()?.name }}</div>
       </div>
       @if (!navigationService.isMobile()) {
         <button (click)="closeThread()" class="close-button filter-hover-purple-3">
@@ -36,12 +36,12 @@
       </li>
 
       <div class="answers-line-container">
-        {{ messages.length }} Antworten
+        {{ messagesService.threadMessages().length }} Antworten
         <div class="line-container"></div>
       </div>
 
       <ul>
-        @for (message of messages; track $index) {
+        @for (message of messagesService.threadMessages(); track $index) {
           <li>
             <app-message-template
               [message]="message"
@@ -58,7 +58,7 @@
       <app-textarea-template
         [reciverId]="currentChannelId"
         [reciverCompontent]="'thread'"
-        [messages]="messages"
+        [messages]="messagesService.threadMessages()"
         [isChannelComponent]="true"
         [placeholderText]="'Antworten...'"
         [threadId]="parentMessageId"

--- a/src/app/features/app_chat/components/chat-thread/chat-thread.component.ts
+++ b/src/app/features/app_chat/components/chat-thread/chat-thread.component.ts
@@ -14,6 +14,8 @@ import { LinkifyPipe } from '../../../pipes/linkify.pipe';
 import { MessageTemplateComponent } from '../message/message-template.component';
 import { AuthService } from '../../../app_auth/services/auth/auth.service';
 import { TextareaTemplateComponent } from '../textarea/textarea-template.component';
+import { UserStore } from '../../../../shared/services/user/user-store';
+import { ChannelService } from '../../../app_channel/services/channel/channel.service';
 
 @Component({
   selector: 'app-thread',
@@ -37,6 +39,8 @@ export class ThreadComponent implements OnInit {
   public userService: UserService = inject(UserService);
   public authService = inject(AuthService);
   public navigationService: NavigationService = inject(NavigationService);
+  private userStore: UserStore = inject(UserStore);
+  public channelService: ChannelService = inject(ChannelService);
   private readonly destroyRef = inject(DestroyRef);
   public currentUser: any;
   public userId: string = '';
@@ -190,11 +194,8 @@ export class ThreadComponent implements OnInit {
    * @param name - The user’s full name to query.
    */
   async caseUser(name: string) {
-    const usersRef = collection(this.firestore, 'users');
-    const q = query(usersRef, where('displayName', '==', name));
-    const snapshot = await getDocs(q);
-    const userDoc = snapshot.docs[0];
-    this.navigationService.selectDirectMessageRecipient(userDoc.id);
+    const user = await this.userStore.findUserByDisplayName(name);
+    if (user) this.navigationService.selectDirectMessageRecipient(user.id);
   }
 
   /**
@@ -205,11 +206,8 @@ export class ThreadComponent implements OnInit {
    * @param name - The channel’s name to query.
    */
   async caseChannel(name: string) {
-    const channelsRef = collection(this.firestore, 'channels');
-    const q = query(channelsRef, where('name', '==', name));
-    const snapshot = await getDocs(q);
-    const channelDoc = snapshot.docs[0];
-    this.navigationService.selectChannel(channelDoc.id);
+    const channel = await this.channelService.findChannelByName(name);
+    if (channel?.id) this.navigationService.selectChannel(channel.id);
   }
 
   ngOnDestroy(): void {

--- a/src/app/features/app_chat/components/chat-thread/chat-thread.component.ts
+++ b/src/app/features/app_chat/components/chat-thread/chat-thread.component.ts
@@ -3,7 +3,6 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { Firestore, collection, doc, getDoc, getDocs, onSnapshot, orderBy, query, where } from '@angular/fire/firestore';
 import { MatIconModule } from '@angular/material/icon';
 
 import { ChatHeaderComponent } from '../chat-header/chat-header.component';
@@ -33,9 +32,8 @@ import { ChannelService } from '../../../app_channel/services/channel/channel.se
 })
 export class ThreadComponent implements OnInit {
   @ViewChild('chat') chatContentRef!: ElementRef;
-  private firestore: Firestore = inject(Firestore);
   private route: ActivatedRoute = inject(ActivatedRoute);
-  private messagesService: MessagesService = inject(MessagesService);
+  public messagesService: MessagesService = inject(MessagesService);
   public userService: UserService = inject(UserService);
   public authService = inject(AuthService);
   public navigationService: NavigationService = inject(NavigationService);
@@ -44,7 +42,6 @@ export class ThreadComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
   public currentUser: any;
   public userId: string = '';
-  public currentChannel: any;
   public currentChannelId: string = '';
   public parentMessageId: string = '';
   public inputEdit: string = '';
@@ -52,7 +49,6 @@ export class ThreadComponent implements OnInit {
   public editingMessageId: number | null = null;
   public listOpen: boolean = false;
   public isEditing: boolean = false;
-  public messages: any = [];
   public reactions: any = [];
 
   /**
@@ -71,7 +67,6 @@ export class ThreadComponent implements OnInit {
       this.userId = params['currentUserId'] || '';
       this.parentMessageId = params['messageId'] || '';
 
-      await this.getCurrentChannel();
       this.getThreadParentMessage();
       this.getMessages();
       this.currentUser = this.authService.currentUser();
@@ -79,28 +74,14 @@ export class ThreadComponent implements OnInit {
   }
 
   /**
-   * Fetches the current channel information from Firestore.
-   */
-  private async getCurrentChannel() {
-    if (this.currentChannelId) {
-      let channelRef = doc(this.firestore, `channels/${this.currentChannelId}`);
-      let channelRefDocSnap = await getDoc(channelRef);
-      channelRefDocSnap.exists() ? (this.currentChannel = channelRefDocSnap.data()) : null;
-    }
-  }
-
-  /**
    * Fetches the parent message details for the thread.
    */
   private async getThreadParentMessage() {
     if (this.parentMessageId) {
-      let parentMessageDocRef = doc(this.firestore, `channels/${this.currentChannelId}/messages/${this.parentMessageId}`);
-      let parentMessageDocSnap = await getDoc(parentMessageDocRef);
-
-      if (parentMessageDocSnap.exists()) {
-        let data = parentMessageDocSnap.data();
-        this.setParentMessageData(data);
-      }
+      const data = await this.messagesService.getParentMessage(this.currentChannelId, this.parentMessageId);
+      if (data) this.setParentMessageData(data);
+    } else {
+      this.parentMessageData = null;
     }
   }
 
@@ -128,14 +109,9 @@ export class ThreadComponent implements OnInit {
     this.unsubMessages = undefined;
 
     if (this.parentMessageId) {
-      let threadRef = collection(this.firestore, `channels/${this.currentChannelId}/messages/${this.parentMessageId}/thread`);
-      let threadQuery = query(threadRef, orderBy('timestamp', 'asc'));
-
-      this.unsubMessages = onSnapshot(threadQuery, (snapshot) => {
-        this.messages = this.messagesService.processData(snapshot);
-      });
+      this.unsubMessages = this.messagesService.subToThreadMessages(this.currentChannelId, this.parentMessageId);
     } else {
-      this.messages = [];
+      this.messagesService.threadMessages.set([]);
     }
   }
 
@@ -214,5 +190,6 @@ export class ThreadComponent implements OnInit {
     if (this.unsubMessages) {
       this.unsubMessages();
     }
+    this.messagesService.threadMessages.set([]);
   }
 }

--- a/src/app/features/app_chat/components/message/message-template.component.ts
+++ b/src/app/features/app_chat/components/message/message-template.component.ts
@@ -7,12 +7,12 @@ import { MatIconModule } from '@angular/material/icon';
 import { FormsModule } from '@angular/forms';
 
 import { MatDialog } from '@angular/material/dialog';
-import { collection, getDocs, query, where } from '@firebase/firestore';
 import { NavigationService } from '../../../../shared/services/navigation/navigation.service';
 import emojiData from 'unicode-emoji-json';
 
-import { Firestore } from '@angular/fire/firestore';
 import { LinkifyPipe } from '../../../pipes/linkify.pipe';
+import { UserStore } from '../../../../shared/services/user/user-store';
+import { ChannelService } from '../../../app_channel/services/channel/channel.service';
 
 import { DialogReciverComponent } from '../../../dialogs/dialog-reciver/dialog-reciver.component';
 import { ChannelMessage } from '../../models/channel-message/channel-message';
@@ -31,7 +31,8 @@ export class MessageTemplateComponent {
   public authService = inject(AuthService);
   private dialog = inject(MatDialog);
   public navigationService: NavigationService = inject(NavigationService);
-  private firestore: Firestore = inject(Firestore);
+  private userStore: UserStore = inject(UserStore);
+  private channelService: ChannelService = inject(ChannelService);
   menuOpen: boolean = false;
   reactionMenuOpen: boolean = false;
   reactionMenuOpenInFooter: boolean = false;
@@ -259,22 +260,9 @@ export class MessageTemplateComponent {
    *          or null if no matching user is found.
    */
   private async _getReceiverByName(): Promise<User | null> {
-    const usersCollection = this.fireService.getCollectionRef('users');
     const searchName = this.message().name;
     if (!searchName) return null;
-
-    const q = query(usersCollection!, where('displayName', '==', searchName));
-    const querySnapshot = await getDocs(q);
-
-    if (!querySnapshot.empty) {
-      const doc = querySnapshot.docs[0];
-      const user = {
-        ...(doc.data() as Omit<User, 'id'>),
-        id: doc.id,
-      } as User;
-      return user;
-    }
-    return null;
+    return this.userStore.findUserByDisplayName(searchName);
   }
 
   /**
@@ -325,11 +313,8 @@ export class MessageTemplateComponent {
    * @param name - The user’s full name to query.
    */
   async caseUser(name: string) {
-    const usersRef = collection(this.firestore, 'users');
-    const q = query(usersRef, where('displayName', '==', name));
-    const snapshot = await getDocs(q);
-    const userDoc = snapshot.docs[0];
-    this.navigationService.selectDirectMessageRecipient(userDoc.id);
+    const user = await this.userStore.findUserByDisplayName(name);
+    if (user) this.navigationService.selectDirectMessageRecipient(user.id);
   }
 
   /**
@@ -340,10 +325,7 @@ export class MessageTemplateComponent {
    * @param name - The channel’s name to query.
    */
   async caseChannel(name: string) {
-    const channelsRef = collection(this.firestore, 'channels');
-    const q = query(channelsRef, where('name', '==', name));
-    const snapshot = await getDocs(q);
-    const channelDoc = snapshot.docs[0];
-    this.navigationService.selectChannel(channelDoc.id);
+    const channel = await this.channelService.findChannelByName(name);
+    if (channel?.id) this.navigationService.selectChannel(channel.id);
   }
 }

--- a/src/app/features/app_chat/services/messages/messages.service.ts
+++ b/src/app/features/app_chat/services/messages/messages.service.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable, signal } from '@angular/core';
-import { onSnapshot, orderBy, query, QuerySnapshot, serverTimestamp } from '@angular/fire/firestore';
+import { getDoc, onSnapshot, orderBy, query, QuerySnapshot } from '@angular/fire/firestore';
 import { FireServiceService } from '../../../../shared/services/firebase/fire-service.service';
 import { ChannelMessage } from '../../models/channel-message/channel-message';
 import { DirectMessage } from '../../models/direct-message/direct-message';
@@ -13,6 +13,7 @@ export class MessagesService {
   private readonly authService = inject(AuthService);
 
   public messages = signal<ChannelMessage[] | DirectMessage[]>([]);
+  public threadMessages = signal<(ChannelMessage | DirectMessage)[]>([]);
 
   public subToMessages(channelId: string | null) {
     if (!channelId) return () => {};
@@ -24,6 +25,31 @@ export class MessagesService {
     return onSnapshot(messagesQuery, (snapshot) => {
       this.messages.set(this.processData(snapshot));
     });
+  }
+
+  /**
+   * Streams the replies of a thread into the threadMessages signal.
+   * @returns The unsubscribe function of the listener.
+   */
+  public subToThreadMessages(channelId: string, parentMessageId: string): () => void {
+    const threadRef = this.fireService.getCollectionRef(`channels/${channelId}/messages/${parentMessageId}/thread`);
+    if (!threadRef) return () => {};
+
+    const threadQuery = query(threadRef, orderBy('timestamp', 'asc'));
+    return onSnapshot(threadQuery, (snapshot) => {
+      this.threadMessages.set(this.processData(snapshot));
+    });
+  }
+
+  /**
+   * Fetches the parent message of a thread once.
+   */
+  public async getParentMessage(channelId: string, messageId: string): Promise<any | null> {
+    const messageRef = this.fireService.getMessageRef(channelId, messageId);
+    if (!messageRef) return null;
+
+    const snap = await getDoc(messageRef);
+    return snap.exists() ? { id: snap.id, ...snap.data() } : null;
   }
 
   public subToConversationMessages(userA: string, userB: string): () => void {

--- a/src/app/shared/services/user/user-store.ts
+++ b/src/app/shared/services/user/user-store.ts
@@ -1,4 +1,5 @@
-import { Injectable, signal } from '@angular/core';
+import { inject, Injectable, signal } from '@angular/core';
+import { collection, Firestore, getDocs, query, where } from '@angular/fire/firestore';
 import { User } from '../../../features/app_auth/models/user/user';
 
 /**
@@ -10,10 +11,23 @@ import { User } from '../../../features/app_auth/models/user/user';
   providedIn: 'root',
 })
 export class UserStore {
+  private readonly firestore = inject(Firestore);
+
   private readonly _currentUser = signal<User | null>(null);
   public readonly currentUser = this._currentUser.asReadonly();
 
   public setCurrentUser(user: User | null): void {
     this._currentUser.set(user);
+  }
+
+  /**
+   * Looks up a user document by its displayName (used for @mentions).
+   */
+  public async findUserByDisplayName(displayName: string): Promise<User | null> {
+    const usersRef = collection(this.firestore, 'users');
+    const q = query(usersRef, where('displayName', '==', displayName));
+    const snapshot = await getDocs(q);
+    const docSnap = snapshot.docs[0];
+    return docSnap ? ({ ...(docSnap.data() as Omit<User, 'id'>), id: docSnap.id } as User) : null;
   }
 }

--- a/src/app/shared/services/user/user-store.ts
+++ b/src/app/shared/services/user/user-store.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable, signal } from '@angular/core';
-import { collection, Firestore, getDocs, query, where } from '@angular/fire/firestore';
+import { collection, doc, Firestore, getDoc, getDocs, query, where } from '@angular/fire/firestore';
 import { User } from '../../../features/app_auth/models/user/user';
 
 /**
@@ -18,6 +18,15 @@ export class UserStore {
 
   public setCurrentUser(user: User | null): void {
     this._currentUser.set(user);
+  }
+
+  /**
+   * Fetches a user document by its id.
+   */
+  public async getUserById(id: string): Promise<User | null> {
+    if (!id) return null;
+    const snap = await getDoc(doc(this.firestore, 'users', id));
+    return snap.exists() ? ({ ...(snap.data() as Omit<User, 'id'>), id: snap.id } as User) : null;
   }
 
   /**


### PR DESCRIPTION
Setzt **Phase 5 der Refactoring-Roadmap** um (stacked auf #16; Merge-Reihenfolge #11 → #14 → #15 → #16 → dieser PR).

### Änderungen (je 1 Commit)
- **Mention-Lookups**: `UserStore.findUserByDisplayName()` und `ChannelService.findChannelByName()` ersetzen die vier kopierten `query/where`-Blöcke in message-template und chat-thread; Mention-Klick crasht nicht mehr, wenn kein Dokument matcht. message-template injiziert kein `Firestore` mehr
- **Thread-Datenzugriff** in MessagesService: `subToThreadMessages()` streamt Antworten in ein `threadMessages`-Signal, `getParentMessage()` holt die Parent-Nachricht; chat-thread konsumiert nur noch Signale und nutzt für den Channel-Namen das Live-Signal aus Phase 4 statt eines eigenen Fetches
- **Rest-Aufräumen**: chat-direct löst den Empfänger über `UserStore.getUserById()` auf; login wirft ungenutzte `Auth`/`Firestore`/`FireService`-Injections raus

### Bewusst verschoben
Die interne Gliederung des FireService in `UsersApi`/`ChannelsApi`/`MessagesApi` (rein interne Reorganisation, kein Verhalten) ist auf einen Folge-PR verschoben, um diesen Diff reviewbar zu halten.

### Verifikation
`ng build` grün nach jedem Commit. Smoke-Test: Mention auf User UND Channel, Reaktion hinzufügen/entfernen, Thread mit >2 Antworten, Direct Message öffnen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)