### PR TITLE
Phase 6: Duplizierung entfernen & Service-SRP

### DIFF
--- a/src/app/features/app_auth/components/avatar-selection/avatar-selection.component.html
+++ b/src/app/features/app_auth/components/avatar-selection/avatar-selection.component.html
@@ -11,16 +11,7 @@
 
   <p>Aus der Liste wählen</p>
 
-  <div class="avatar-selection-box">
-    @for (avatar of avatars; track avatar) {
-      <img
-        [src]="'img/avatars/' + avatar"
-        [alt]="avatar"
-        (click)="selectAvatar(avatar)"
-        [class.selected]="currentAvatar() === 'img/avatars/' + avatar"
-      />
-    }
-  </div>
+  <app-avatar-picker [(selected)]="currentAvatar"></app-avatar-picker>
 </main>
 
 <footer class="footer">

--- a/src/app/features/app_auth/components/avatar-selection/avatar-selection.component.ts
+++ b/src/app/features/app_auth/components/avatar-selection/avatar-selection.component.ts
@@ -2,24 +2,19 @@ import { Component, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { AuthService } from '../../services/auth/auth.service';
+import { AvatarPickerComponent } from '../../../../shared/components/avatar-picker/avatar-picker.component';
+import { DEFAULT_AVATAR } from '../../../../shared/constants';
 
 @Component({
   selector: 'app-avatarselection',
-  imports: [CommonModule, RouterModule],
+  imports: [CommonModule, RouterModule, AvatarPickerComponent],
   templateUrl: './avatar-selection.component.html',
   styleUrls: ['./avatar-selection.component.scss'],
 })
 export class AvatarselectionComponent {
-  public currentAvatar = signal<string>('img/avatars/avatar_default.png');
+  public currentAvatar = signal<string>(DEFAULT_AVATAR);
 
   public readonly authService: AuthService = inject(AuthService);
-
-  public avatars = ['avatar_1.png', 'avatar_2.png', 'avatar_3.png', 'avatar_4.png', 'avatar_5.png', 'avatar_6.png'];
-
-  public selectAvatar(avatar: string) {
-    const fullPath = `img/avatars/${avatar}`;
-    this.currentAvatar.set(fullPath);
-  }
 
   public onSubmit() {
     this.authService.completeRegistration(this.currentAvatar());

--- a/src/app/features/app_auth/components/login/login.component.ts
+++ b/src/app/features/app_auth/components/login/login.component.ts
@@ -1,10 +1,11 @@
 import { Component, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { MatDividerModule } from '@angular/material/divider';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatIconModule } from '@angular/material/icon';
 import { AuthService } from '../../services/auth/auth.service';
 import { NavigationService } from '../../../../shared/services/navigation/navigation.service';
+import { createLoginForm } from '../../forms/auth-forms';
 
 @Component({
   selector: 'app-login',
@@ -17,7 +18,7 @@ export class LoginComponent {
   authService: AuthService = inject(AuthService);
   navigationService: NavigationService = inject(NavigationService);
 
-  public loginForm = this.authService.createLoginForm();
+  public loginForm = createLoginForm(inject(FormBuilder));
 
   /**
    * Signs in the user with email and password.

--- a/src/app/features/app_auth/components/login/login.component.ts
+++ b/src/app/features/app_auth/components/login/login.component.ts
@@ -1,12 +1,8 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { MatDividerModule } from '@angular/material/divider';
-import { Auth } from '@angular/fire/auth';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { Firestore } from '@angular/fire/firestore';
 import { MatIconModule } from '@angular/material/icon';
-import { UserService } from '../../../../shared/services/user/shared.service';
-import { FireServiceService } from '../../../../shared/services/firebase/fire-service.service';
 import { AuthService } from '../../services/auth/auth.service';
 import { NavigationService } from '../../../../shared/services/navigation/navigation.service';
 
@@ -18,10 +14,6 @@ import { NavigationService } from '../../../../shared/services/navigation/naviga
 })
 export class LoginComponent {
   disabled = true;
-  shared = inject(UserService);
-  auth = inject(Auth);
-  firestore = inject(Firestore);
-  fireService = inject(FireServiceService);
   authService: AuthService = inject(AuthService);
   navigationService: NavigationService = inject(NavigationService);
 

--- a/src/app/features/app_auth/components/register/register.component.ts
+++ b/src/app/features/app_auth/components/register/register.component.ts
@@ -1,9 +1,10 @@
-import { Component, inject, OnInit } from '@angular/core';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { Component, inject } from '@angular/core';
+import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { MatIcon } from '@angular/material/icon';
 import { AuthService } from '../../services/auth/auth.service';
 import { NavigationService } from '../../../../shared/services/navigation/navigation.service';
+import { createRegisterForm } from '../../forms/auth-forms';
 
 @Component({
   selector: 'app-register',
@@ -14,7 +15,7 @@ import { NavigationService } from '../../../../shared/services/navigation/naviga
 export class RegisterComponent {
   public authService: AuthService = inject(AuthService);
   private navigationService: NavigationService = inject(NavigationService);
-  public registerForm = this.authService.createRegisterForm();
+  public registerForm = createRegisterForm(inject(FormBuilder));
 
   public onSubmit() {
     if (this.registerForm.invalid) {

--- a/src/app/features/app_auth/components/reset-password/reset-password.component.ts
+++ b/src/app/features/app_auth/components/reset-password/reset-password.component.ts
@@ -44,9 +44,7 @@ export class ResetpasswordComponent implements OnInit {
    */
   ngOnInit() {
     this.auth = getAuth(this.afApp);
-    this.activatedRoute.queryParams.subscribe((params) => {
-      this.resetCode = params['oobCode'] || '';
-    });
+    this.resetCode = this.activatedRoute.snapshot.queryParamMap.get('oobCode') || '';
     verifyPasswordResetCode(this.auth, this.resetCode)
       .then((email) => {
         this.email = email;

--- a/src/app/features/app_auth/forms/auth-forms.ts
+++ b/src/app/features/app_auth/forms/auth-forms.ts
@@ -1,0 +1,26 @@
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+
+export const PASSWORD_PATTERN = '^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).{6,}$';
+
+/**
+ * Shared email/password controls used by login and registration.
+ */
+function basicAuthFields() {
+  return {
+    email: ['', [Validators.required, Validators.email]],
+    password: ['', [Validators.required, Validators.minLength(6), Validators.pattern(PASSWORD_PATTERN)]],
+  };
+}
+
+export function createLoginForm(formBuilder: FormBuilder): FormGroup {
+  return formBuilder.group(basicAuthFields());
+}
+
+export function createRegisterForm(formBuilder: FormBuilder): FormGroup {
+  return formBuilder.group({
+    ...basicAuthFields(),
+    displayName: ['', [Validators.required, Validators.minLength(5)]],
+    photoURL: ['img/avatar_default.png'],
+    acceptTerms: [false, [Validators.requiredTrue]],
+  });
+}

--- a/src/app/features/app_auth/services/auth/auth.service.ts
+++ b/src/app/features/app_auth/services/auth/auth.service.ts
@@ -9,6 +9,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 
 import { NavigationService } from '../../../../shared/services/navigation/navigation.service';
 import { FireServiceService } from '../../../../shared/services/firebase/fire-service.service';
+import { UserStore } from '../../../../shared/services/user/user-store';
 import { RegisterData, User } from '../../models/user/user';
 import { DEFAULT_CHANNEL_ID, GUEST_EMAIL } from '../../../../shared/constants';
 
@@ -31,8 +32,8 @@ export class AuthService {
   private readonly passwordPattern = '^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).{6,}$';
   private tempUserData = signal<RegisterData | null>(null);
 
-  private _currentUser = signal<User | null>(null);
-  public currentUser = this._currentUser.asReadonly();
+  private userStore = inject(UserStore);
+  public currentUser = this.userStore.currentUser;
   private unsubUserDoc?: () => void;
 
   constructor() {
@@ -223,18 +224,18 @@ export class AuthService {
       this.unsubUserDoc = undefined;
 
       if (firebaseUser) {
-        this._currentUser.set(this.mapFirebaseUserToUser(firebaseUser));
+        this.userStore.setCurrentUser(this.mapFirebaseUserToUser(firebaseUser));
 
         const userDocRef = doc(this.firestore, `users/${firebaseUser.uid}`);
 
         this.unsubUserDoc = onSnapshot(userDocRef, (docSnap) => {
           if (docSnap.exists()) {
             const firestoreData = docSnap.data() as User;
-            this._currentUser.set(firestoreData);
+            this.userStore.setCurrentUser(firestoreData);
           }
         });
       } else {
-        this._currentUser.set(null);
+        this.userStore.setCurrentUser(null);
       }
     });
   }

--- a/src/app/features/app_auth/services/auth/auth.service.ts
+++ b/src/app/features/app_auth/services/auth/auth.service.ts
@@ -10,6 +10,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { NavigationService } from '../../../../shared/services/navigation/navigation.service';
 import { FireServiceService } from '../../../../shared/services/firebase/fire-service.service';
 import { RegisterData, User } from '../../models/user/user';
+import { DEFAULT_CHANNEL_ID, GUEST_EMAIL } from '../../../../shared/constants';
 
 @Injectable({
   providedIn: 'root',
@@ -109,7 +110,7 @@ export class AuthService {
    * @param user - The user to be added to the default channel
    */
   private async addInDefaultChannel(user: User) {
-    const defaultChannelRef = doc(this.firestore, `channels/KqvcY68R1jP2UsQkv6Nz`);
+    const defaultChannelRef = doc(this.firestore, `channels/${DEFAULT_CHANNEL_ID}`);
     try {
       await updateDoc(defaultChannelRef, {
         member: arrayUnion({
@@ -178,7 +179,6 @@ export class AuthService {
    */
   public async loginAsGuest() {
     this.isLoading = true;
-    const GUEST_EMAIL = 'gast@portfolio.de';
     const GUEST_PW = 'Gast1234';
 
     try {

--- a/src/app/features/app_auth/services/auth/auth.service.ts
+++ b/src/app/features/app_auth/services/auth/auth.service.ts
@@ -32,6 +32,7 @@ export class AuthService {
 
   private _currentUser = signal<User | null>(null);
   public currentUser = this._currentUser.asReadonly();
+  private unsubUserDoc?: () => void;
 
   constructor() {
     this.setCurrentUser();
@@ -218,12 +219,15 @@ export class AuthService {
    */
   setCurrentUser() {
     onAuthStateChanged(this.auth, (firebaseUser) => {
+      this.unsubUserDoc?.();
+      this.unsubUserDoc = undefined;
+
       if (firebaseUser) {
         this._currentUser.set(this.mapFirebaseUserToUser(firebaseUser));
 
         const userDocRef = doc(this.firestore, `users/${firebaseUser.uid}`);
 
-        onSnapshot(userDocRef, (docSnap) => {
+        this.unsubUserDoc = onSnapshot(userDocRef, (docSnap) => {
           if (docSnap.exists()) {
             const firestoreData = docSnap.data() as User;
             this._currentUser.set(firestoreData);

--- a/src/app/features/app_auth/services/auth/auth.service.ts
+++ b/src/app/features/app_auth/services/auth/auth.service.ts
@@ -5,7 +5,6 @@ import { Auth, createUserWithEmailAndPassword, GoogleAuthProvider, signInWithPop
 import { arrayUnion, doc, onSnapshot, setDoc, updateDoc } from '@angular/fire/firestore';
 import { Firestore } from '@angular/fire/firestore';
 import { onAuthStateChanged, signInWithEmailAndPassword } from '@firebase/auth';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 
 import { NavigationService } from '../../../../shared/services/navigation/navigation.service';
 import { FireServiceService } from '../../../../shared/services/firebase/fire-service.service';
@@ -27,9 +26,6 @@ export class AuthService {
 
   public errorMessage = signal<string | null>(null);
 
-  //Ab hier refactored
-  private formBuilder = inject(FormBuilder);
-  private readonly passwordPattern = '^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).{6,}$';
   private tempUserData = signal<RegisterData | null>(null);
 
   private userStore = inject(UserStore);
@@ -286,46 +282,4 @@ export class AuthService {
     }
   }
 
-  /**
-   * Gemeinsame Basis-Konfiguration für Login und Register
-   */
-  private get basicAuthFields() {
-    return {
-      email: ['', [Validators.required, Validators.email]],
-      password: ['', [Validators.required, Validators.minLength(6), Validators.pattern(this.passwordPattern)]],
-    };
-  }
-
-  /**
-   * Initializes and configures the FormGroup for the login process.
-   * * @description
-   * Defines a form group containing 'email' and 'password' fields with the following rules:
-   * - **email**: Required, must follow a valid email format.
-   * - **password**: Required field.
-   * * @returns {FormGroup} A configured FormGroup instance ready for template binding.
-   */
-  public createLoginForm(): FormGroup {
-    return this.formBuilder.group(this.basicAuthFields);
-  }
-
-  /**
-   * Initializes and configures the FormGroup for the user registration process.
-   * * @description
-   * This method extends the basic authentication fields (email and password)
-   * with additional fields required for creating a new user account:
-   * - **email**: Inherited from basicAuthFields (Required, Email format).
-   * - **password**: Inherited from basicAuthFields (Required, Min length 6).
-   * - **displayName**: Required field, minimum of 2 characters.
-   * - **photoURL**: Optional, defaults to a standard placeholder path.
-   * - **acceptTerms**: Required to be 'true' (checkbox must be checked).
-   * * @returns {FormGroup} A fully configured FormGroup for the registration template.
-   */
-  public createRegisterForm(): FormGroup {
-    return this.formBuilder.group({
-      ...this.basicAuthFields,
-      displayName: ['', [Validators.required, Validators.minLength(5)]],
-      photoURL: ['img/avatar_default.png'],
-      acceptTerms: [false, [Validators.requiredTrue]],
-    });
-  }
 }

--- a/src/app/features/app_channel/components/add-member/add-member.component.ts
+++ b/src/app/features/app_channel/components/add-member/add-member.component.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component, inject, signal } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 
 import { DialogReciverComponent } from '../../../dialogs/dialog-reciver/dialog-reciver.component';
 import { AuthService } from '../../../app_auth/services/auth/auth.service';
@@ -22,7 +22,6 @@ export class AddMemberComponent {
   private readonly dialog = inject(MatDialog);
 
   public readonly dialogRef = inject(MatDialogRef<AddMemberComponent>);
-  public readonly data = inject<any>(MAT_DIALOG_DATA);
 
   showUserBar: boolean = false;
   addMemberWindow: boolean = false;
@@ -30,7 +29,6 @@ export class AddMemberComponent {
   public isSubmiting = signal<boolean>(false);
 
   constructor() {
-    this.channelService.currentChannel.set(this.data);
     this.channelService.allMembersSelected.set(false);
     this.channelService.resetSelection();
   }

--- a/src/app/features/app_channel/components/edit.channel/edit.channel.component.ts
+++ b/src/app/features/app_channel/components/edit.channel/edit.channel.component.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component, inject, computed, signal } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { UserService } from '../../../../shared/services/user/shared.service';
 import { NavigationService } from '../../../../shared/services/navigation/navigation.service';
 import { DialogReciverComponent } from '../../../dialogs/dialog-reciver/dialog-reciver.component';
@@ -8,7 +8,6 @@ import { User } from '../../../app_auth/models/user/user';
 import { MatIcon } from '@angular/material/icon';
 import { FormsModule } from '@angular/forms';
 import { ChannelService } from '../../services/channel/channel.service';
-import { Channel } from '../../models/channel/channel';
 import { ProfileStatusComponent } from '../../../../shared/components/profile-status/profile-status.component';
 
 @Component({
@@ -23,7 +22,6 @@ export class EditChannelComponent {
   private readonly dialog = inject(MatDialog);
   private readonly dialogRef: MatDialogRef<EditChannelComponent> = inject(MatDialogRef<EditChannelComponent>);
   public readonly channelService = inject(ChannelService);
-  public readonly data = inject<Channel>(MAT_DIALOG_DATA);
 
   public channelNameEdit: boolean = false;
   public channelDescriptionEdit: boolean = false;
@@ -33,7 +31,6 @@ export class EditChannelComponent {
   public showUserBar: boolean = false;
 
   constructor() {
-    this.channelService.currentChannel.set(this.data);
     this.channelService.allMembersSelected.set(false);
     this.channelService.resetSelection();
   }

--- a/src/app/features/app_channel/services/channel/channel.service.ts
+++ b/src/app/features/app_channel/services/channel/channel.service.ts
@@ -1,4 +1,5 @@
 import { computed, inject, Injectable, signal } from '@angular/core';
+import { onSnapshot } from '@angular/fire/firestore';
 import { FireServiceService } from '../../../../shared/services/firebase/fire-service.service';
 import { User } from '../../../app_auth/models/user/user';
 import { AuthService } from '../../../app_auth/services/auth/auth.service';
@@ -16,6 +17,7 @@ export class ChannelService {
   private readonly authService = inject(AuthService);
 
   public currentChannel = signal<Channel | null>(null);
+  private unsubCurrentChannel?: () => void;
   public selectedUsers = signal<User[]>([]);
   public userSearchQuery = signal('');
   public allMembersSelected = signal<boolean>(false);
@@ -87,6 +89,28 @@ export class ChannelService {
   });
 
   private isSubmitting = signal<boolean>(false);
+
+  /**
+   * Single source of truth for the active channel: holds THE one
+   * Firestore listener on the channel document (derived from the route
+   * param) and feeds the currentChannel signal. Passing null clears it.
+   */
+  public setActiveChannel(id: string | null): void {
+    this.unsubCurrentChannel?.();
+    this.unsubCurrentChannel = undefined;
+
+    if (!id) {
+      this.currentChannel.set(null);
+      return;
+    }
+
+    const channelRef = this.fireService.getDocRef('channels', id);
+    if (!channelRef) return;
+
+    this.unsubCurrentChannel = onSnapshot(channelRef, (snap) => {
+      this.currentChannel.set(snap.exists() ? ({ id: snap.id, ...snap.data() } as Channel) : null);
+    });
+  }
 
   async createChannel(channelData: Channel) {
     try {

--- a/src/app/features/app_channel/services/channel/channel.service.ts
+++ b/src/app/features/app_channel/services/channel/channel.service.ts
@@ -151,12 +151,10 @@ export class ChannelService {
 
   public async updateName(id: string, name: string) {
     await this.fireService.updateChannelData(id, { name });
-    this.currentChannel.update((c) => ({ ...c, name }) as Channel);
   }
 
   public async updateDescription(id: string, description: string) {
     await this.fireService.updateChannelData(id, { description });
-    this.currentChannel.update((c) => ({ ...c, description }) as Channel);
   }
 
   public async addMembers(id: string, userObjects: { id: string }[]) {
@@ -166,19 +164,6 @@ export class ChannelService {
       this.isSubmitting.set(true);
 
       await this.fireService.addChannelMembers(id, userObjects);
-
-      this.currentChannel.update((current) => {
-        if (!current) return null;
-
-        const existingIds = new Set((current.member || []).map((m: any) => m.id));
-        const newUniqueMembers = userObjects.filter((obj) => !existingIds.has(obj.id));
-
-        return {
-          ...current,
-          member: [...(current.member || []), ...newUniqueMembers],
-        } as Channel;
-      });
-
       this.resetSelection();
     } catch (error) {
       console.error('Fehler beim Hinzufügen der Mitglieder:', error);

--- a/src/app/features/app_channel/services/channel/channel.service.ts
+++ b/src/app/features/app_channel/services/channel/channel.service.ts
@@ -1,5 +1,5 @@
 import { computed, inject, Injectable, signal } from '@angular/core';
-import { onSnapshot } from '@angular/fire/firestore';
+import { getDocs, onSnapshot, query, where } from '@angular/fire/firestore';
 import { FireServiceService } from '../../../../shared/services/firebase/fire-service.service';
 import { User } from '../../../app_auth/models/user/user';
 import { AuthService } from '../../../app_auth/services/auth/auth.service';
@@ -171,6 +171,19 @@ export class ChannelService {
     } finally {
       this.isSubmitting.set(false);
     }
+  }
+
+  /**
+   * Looks up a channel document by its name (used for #mentions).
+   */
+  public async findChannelByName(name: string): Promise<Channel | null> {
+    const channelsRef = this.fireService.getCollectionRef('channels');
+    if (!channelsRef) return null;
+
+    const q = query(channelsRef, where('name', '==', name.trim()));
+    const snapshot = await getDocs(q);
+    const docSnap = snapshot.docs[0];
+    return docSnap ? ({ id: docSnap.id, ...docSnap.data() } as Channel) : null;
   }
 
   public async leaveChannel() {

--- a/src/app/features/app_chat/components/chat-channel/chat-channel.component.html
+++ b/src/app/features/app_chat/components/chat-channel/chat-channel.component.html
@@ -7,7 +7,7 @@
     <section class="card-header">
       <div class="tooltip-cont">
         <div class="addChannel" class="align-center hover-bg cursor-pointer" (click)="openChannelInfo()">
-          # {{ this.currentChannel?.name }}
+          # {{ channelService.currentChannel()?.name }}
           <mat-icon fontIcon="keyboard_arrow_down"></mat-icon>
         </div>
         <span class="tooltip guest-msg-pos">Zugang für Gäste gesperrt</span>
@@ -17,12 +17,12 @@
         <div class="tooltip-cont">
           <div class="avatar-container hover-bg" (click)="openMemberWindow(false)">
             <div class="member-img-cont">
-              @for (member of currentChannel?.member; track $index; let i = $index) {
-                <img *ngIf="i < 3" class="avatar" [src]="member.photoURL" alt="Name" />
+              @for (member of channelService.currentChannel()?.member; track $index; let i = $index) {
+                <img *ngIf="i < 3" class="avatar" [src]="$any(member).photoURL" alt="Name" />
               }
             </div>
-            @if (currentChannel?.member?.length) {
-              <span>{{ currentChannel?.member?.length }}</span>
+            @if (channelService.currentChannel()?.member?.length) {
+              <span>{{ channelService.currentChannel()?.member?.length }}</span>
             }
           </div>
 
@@ -68,11 +68,11 @@
     <section class="card-footer">
       <app-textarea-template
         [reciverId]="currentChannelId() || ''"
-        [reciverName]="currentChannel?.name"
+        [reciverName]="channelService.currentChannel()?.name || ''"
         [reciverCompontent]="'channel'"
         [messages]="this.messagesService.messages()"
         [isChannelComponent]="true"
-        [placeholderText]="'Nachricht an #' + currentChannel?.name"
+        [placeholderText]="'Nachricht an #' + (channelService.currentChannel()?.name || '')"
       ></app-textarea-template>
     </section>
   </div>

--- a/src/app/features/app_chat/components/chat-channel/chat-channel.component.ts
+++ b/src/app/features/app_chat/components/chat-channel/chat-channel.component.ts
@@ -4,7 +4,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
-import { Firestore, onSnapshot, doc } from '@angular/fire/firestore';
+import { ChannelService } from '../../../app_channel/services/channel/channel.service';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { ActivatedRoute } from '@angular/router';
 import { MatMenuModule } from '@angular/material/menu';
@@ -43,7 +43,7 @@ export class ChatContentComponent implements OnInit, OnDestroy {
   @ViewChild('chatContent') chatContentRef!: ElementRef;
   fireService: FireServiceService = inject(FireServiceService);
   userService: UserService = inject(UserService);
-  firestore: Firestore = inject(Firestore);
+  channelService: ChannelService = inject(ChannelService);
   dialog = inject(MatDialog);
   navigationService: NavigationService = inject(NavigationService);
   messagesService: MessagesService = inject(MessagesService);
@@ -55,7 +55,6 @@ export class ChatContentComponent implements OnInit, OnDestroy {
   showBackground: boolean = false;
   channels: any = [];
 
-  currentChannel: any = {};
   channelInfo: boolean = false;
   addMemberInfoWindow: boolean = false;
   addMemberWindow: boolean = false;
@@ -65,19 +64,18 @@ export class ChatContentComponent implements OnInit, OnDestroy {
 
   public currentChannelId = signal<string | null>(null);
 
-  unsubChannelData!: () => void;
   unsubMessages?: () => void;
 
   constructor() {
     effect(() => {
       const channelId = this.currentChannelId();
       untracked(() => {
-        if (this.unsubChannelData) this.unsubChannelData();
         this.unsubMessages?.();
+        this.unsubMessages = undefined;
         if (channelId) {
           this.unsubMessages = this.messagesService.subToMessages(channelId);
-          this.getCurrentChannelData(channelId);
         }
+        this.channelService.setActiveChannel(channelId);
       });
     });
 
@@ -114,27 +112,11 @@ export class ChatContentComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Loads the current channel from Firestore based on the channel ID.
-   */
-  private getCurrentChannelData(channelId: string | null) {
-    if (this.unsubChannelData) this.unsubChannelData();
-
-    if (channelId) {
-      const docRef = doc(this.firestore, 'channels', channelId);
-      this.unsubChannelData = onSnapshot(docRef, (docSnap) => {
-        if (docSnap.exists()) {
-          this.currentChannel = { id: docSnap.id, ...docSnap.data() };
-        }
-      });
-    }
-  }
-
-  /**
    * Opens the dialog to view or edit channel information.
    */
   openChannelInfo() {
     this.dialog.open(EditChannelComponent, {
-      data: this.currentChannel,
+      data: this.channelService.currentChannel(),
       position: { top: '200px' },
       width: '872px',
       maxWidth: '95vw',
@@ -151,7 +133,7 @@ export class ChatContentComponent implements OnInit, OnDestroy {
     this.addMemberWindow = toggle;
 
     this.dialog.open(AddMemberComponent, {
-      data: this.currentChannel,
+      data: this.channelService.currentChannel(),
       width: 'auto',
       maxWidth: '95vw',
       maxHeight: '90vh',
@@ -165,8 +147,8 @@ export class ChatContentComponent implements OnInit, OnDestroy {
    * Cleans up subscriptions and listeners when the component is destroyed.
    */
   ngOnDestroy() {
-    if (this.unsubChannelData) this.unsubChannelData();
     if (this.unsubMessages) this.unsubMessages();
     this.messagesService.messages.set([]);
+    this.channelService.setActiveChannel(null);
   }
 }

--- a/src/app/features/app_chat/components/chat-channel/chat-channel.component.ts
+++ b/src/app/features/app_chat/components/chat-channel/chat-channel.component.ts
@@ -73,6 +73,7 @@ export class ChatContentComponent implements OnInit, OnDestroy {
       const channelId = this.currentChannelId();
       untracked(() => {
         if (this.unsubChannelData) this.unsubChannelData();
+        this.unsubMessages?.();
         if (channelId) {
           this.unsubMessages = this.messagesService.subToMessages(channelId);
           this.getCurrentChannelData(channelId);

--- a/src/app/features/app_chat/components/chat-channel/chat-channel.component.ts
+++ b/src/app/features/app_chat/components/chat-channel/chat-channel.component.ts
@@ -116,7 +116,6 @@ export class ChatContentComponent implements OnInit, OnDestroy {
    */
   openChannelInfo() {
     this.dialog.open(EditChannelComponent, {
-      data: this.channelService.currentChannel(),
       position: { top: '200px' },
       width: '872px',
       maxWidth: '95vw',
@@ -133,7 +132,6 @@ export class ChatContentComponent implements OnInit, OnDestroy {
     this.addMemberWindow = toggle;
 
     this.dialog.open(AddMemberComponent, {
-      data: this.channelService.currentChannel(),
       width: 'auto',
       maxWidth: '95vw',
       maxHeight: '90vh',

--- a/src/app/features/app_chat/components/chat-channel/chat-channel.component.ts
+++ b/src/app/features/app_chat/components/chat-channel/chat-channel.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
-import { Component, ElementRef, inject, OnInit, ViewChild, OnDestroy, untracked, effect, signal } from '@angular/core';
+import { Component, ElementRef, inject, OnInit, ViewChild, OnDestroy, untracked, effect, signal, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -48,6 +49,7 @@ export class ChatContentComponent implements OnInit, OnDestroy {
   messagesService: MessagesService = inject(MessagesService);
   route: ActivatedRoute = inject(ActivatedRoute);
   public chatService: ChatService = inject(ChatService);
+  private readonly destroyRef = inject(DestroyRef);
 
   isMobile: boolean = false;
   showBackground: boolean = false;
@@ -93,7 +95,7 @@ export class ChatContentComponent implements OnInit, OnDestroy {
    * Initializes the component, loads messages and channel data from URL parameters.
    */
   async ngOnInit() {
-    this.route.paramMap.subscribe((params) => {
+    this.route.paramMap.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params) => {
       this.currentChannelId.set(params.get('id'));
     });
   }

--- a/src/app/features/app_chat/components/chat-direct/chat-direct.component.ts
+++ b/src/app/features/app_chat/components/chat-direct/chat-direct.component.ts
@@ -1,6 +1,5 @@
 import { Component, inject, OnInit, ElementRef, ViewChild, OnDestroy, signal, computed, DestroyRef } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { getDoc } from '@angular/fire/firestore';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
@@ -12,7 +11,7 @@ import { DividerTemplateComponent } from '../divider/divider-template.component'
 import { MessageTemplateComponent } from '../message/message-template.component';
 import { UserService } from '../../../../shared/services/user/shared.service';
 import { NavigationService } from '../../../../shared/services/navigation/navigation.service';
-import { FireServiceService } from '../../../../shared/services/firebase/fire-service.service';
+import { UserStore } from '../../../../shared/services/user/user-store';
 import { MessagesService } from '../../services/messages/messages.service';
 import { ChatHeaderComponent } from '../chat-header/chat-header.component';
 import { User } from '../../../app_auth/models/user/user';
@@ -41,7 +40,7 @@ export class DirectmessagesComponent implements OnInit, OnDestroy {
   @ViewChild('chat') chatContentRef!: ElementRef;
   public readonly userService = inject(UserService);
   public readonly navigationService = inject(NavigationService);
-  private readonly firestoreService = inject(FireServiceService);
+  private readonly userStore = inject(UserStore);
   private readonly route: ActivatedRoute = inject(ActivatedRoute);
   public readonly authService = inject(AuthService);
   private readonly dialog = inject(MatDialog);
@@ -73,19 +72,11 @@ export class DirectmessagesComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Retrieves the receiver's data from Firestore using the receiver ID.
+   * Retrieves the receiver's data using the receiver ID from the route.
    */
   private async getRecieverFromUrl() {
-    if (this.currentRecieverId) {
-      const docRef = this.firestoreService.getDocRef('users', this.currentRecieverId() || '');
-      if (docRef) {
-        const docSnap = await getDoc(docRef);
-        if (docSnap.exists()) {
-          const data = docSnap.data();
-          this.currentReciever.set({ id: docSnap.id, ...data } as User);
-        }
-      }
-    }
+    const user = await this.userStore.getUserById(this.currentRecieverId() || '');
+    if (user) this.currentReciever.set(user);
   }
 
   /**

--- a/src/app/features/app_chat/components/chat-direct/chat-direct.component.ts
+++ b/src/app/features/app_chat/components/chat-direct/chat-direct.component.ts
@@ -1,4 +1,5 @@
-import { Component, inject, OnInit, ElementRef, ViewChild, OnDestroy, signal, computed } from '@angular/core';
+import { Component, inject, OnInit, ElementRef, ViewChild, OnDestroy, signal, computed, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { getDoc } from '@angular/fire/firestore';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
@@ -46,6 +47,7 @@ export class DirectmessagesComponent implements OnInit, OnDestroy {
   private readonly dialog = inject(MatDialog);
   public messagesService = inject(MessagesService);
   public chatService: ChatService = inject(ChatService);
+  private readonly destroyRef = inject(DestroyRef);
 
   public currentRecieverId = signal<string | null>(null);
   public currentReciever = signal<User | null>(null);
@@ -55,7 +57,7 @@ export class DirectmessagesComponent implements OnInit, OnDestroy {
    * Initializes the component and loads the necessary data such as receiver information, messages, users, and channels.
    */
   ngOnInit() {
-    this.route.paramMap.subscribe((params) => {
+    this.route.paramMap.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params) => {
       this.currentRecieverId.set(params.get('id'));
       this.getRecieverFromUrl();
       this.loadDirectChat(this.currentRecieverId() || '');

--- a/src/app/features/app_chat/components/chat-thread/chat-thread.component.html
+++ b/src/app/features/app_chat/components/chat-thread/chat-thread.component.html
@@ -8,7 +8,7 @@
         <div class="thread-container">
           <p>Thread</p>
         </div>
-        <div class="channel-name-container"># {{ currentChannel?.name }}</div>
+        <div class="channel-name-container"># {{ channelService.currentChannel()?.name }}</div>
       </div>
       @if (!navigationService.isMobile()) {
         <button (click)="closeThread()" class="close-button filter-hover-purple-3">
@@ -36,12 +36,12 @@
       </li>
 
       <div class="answers-line-container">
-        {{ messages.length }} Antworten
+        {{ messagesService.threadMessages().length }} Antworten
         <div class="line-container"></div>
       </div>
 
       <ul>
-        @for (message of messages; track $index) {
+        @for (message of messagesService.threadMessages(); track $index) {
           <li>
             <app-message-template
               [message]="message"
@@ -58,7 +58,7 @@
       <app-textarea-template
         [reciverId]="currentChannelId"
         [reciverCompontent]="'thread'"
-        [messages]="messages"
+        [messages]="messagesService.threadMessages()"
         [isChannelComponent]="true"
         [placeholderText]="'Antworten...'"
         [threadId]="parentMessageId"

--- a/src/app/features/app_chat/components/chat-thread/chat-thread.component.ts
+++ b/src/app/features/app_chat/components/chat-thread/chat-thread.component.ts
@@ -14,6 +14,8 @@ import { LinkifyPipe } from '../../../pipes/linkify.pipe';
 import { MessageTemplateComponent } from '../message/message-template.component';
 import { AuthService } from '../../../app_auth/services/auth/auth.service';
 import { TextareaTemplateComponent } from '../textarea/textarea-template.component';
+import { UserStore } from '../../../../shared/services/user/user-store';
+import { ChannelService } from '../../../app_channel/services/channel/channel.service';
 
 @Component({
   selector: 'app-thread',
@@ -37,6 +39,8 @@ export class ThreadComponent implements OnInit {
   public userService: UserService = inject(UserService);
   public authService = inject(AuthService);
   public navigationService: NavigationService = inject(NavigationService);
+  private userStore: UserStore = inject(UserStore);
+  public channelService: ChannelService = inject(ChannelService);
   private readonly destroyRef = inject(DestroyRef);
   public currentUser: any;
   public userId: string = '';
@@ -190,11 +194,8 @@ export class ThreadComponent implements OnInit {
    * @param name - The user’s full name to query.
    */
   async caseUser(name: string) {
-    const usersRef = collection(this.firestore, 'users');
-    const q = query(usersRef, where('displayName', '==', name));
-    const snapshot = await getDocs(q);
-    const userDoc = snapshot.docs[0];
-    this.navigationService.selectDirectMessageRecipient(userDoc.id);
+    const user = await this.userStore.findUserByDisplayName(name);
+    if (user) this.navigationService.selectDirectMessageRecipient(user.id);
   }
 
   /**
@@ -205,11 +206,8 @@ export class ThreadComponent implements OnInit {
    * @param name - The channel’s name to query.
    */
   async caseChannel(name: string) {
-    const channelsRef = collection(this.firestore, 'channels');
-    const q = query(channelsRef, where('name', '==', name));
-    const snapshot = await getDocs(q);
-    const channelDoc = snapshot.docs[0];
-    this.navigationService.selectChannel(channelDoc.id);
+    const channel = await this.channelService.findChannelByName(name);
+    if (channel?.id) this.navigationService.selectChannel(channel.id);
   }
 
   ngOnDestroy(): void {

--- a/src/app/features/app_chat/components/chat-thread/chat-thread.component.ts
+++ b/src/app/features/app_chat/components/chat-thread/chat-thread.component.ts
@@ -133,7 +133,7 @@ export class ThreadComponent implements OnInit {
    * Closes the current thread and redirects the user.
    */
   public closeThread() {
-    if (!this.navigationService.isMobile()) this.navigationService.toggleThread('close');
+    this.navigationService.toggleThread('close');
   }
 
   /**

--- a/src/app/features/app_chat/components/chat-thread/chat-thread.component.ts
+++ b/src/app/features/app_chat/components/chat-thread/chat-thread.component.ts
@@ -13,8 +13,8 @@ import { LinkifyPipe } from '../../../pipes/linkify.pipe';
 import { MessageTemplateComponent } from '../message/message-template.component';
 import { AuthService } from '../../../app_auth/services/auth/auth.service';
 import { TextareaTemplateComponent } from '../textarea/textarea-template.component';
-import { UserStore } from '../../../../shared/services/user/user-store';
 import { ChannelService } from '../../../app_channel/services/channel/channel.service';
+import { MentionService } from '../../../../shared/services/mention/mention.service';
 
 @Component({
   selector: 'app-thread',
@@ -37,8 +37,8 @@ export class ThreadComponent implements OnInit {
   public userService: UserService = inject(UserService);
   public authService = inject(AuthService);
   public navigationService: NavigationService = inject(NavigationService);
-  private userStore: UserStore = inject(UserStore);
   public channelService: ChannelService = inject(ChannelService);
+  private mentionService: MentionService = inject(MentionService);
   private readonly destroyRef = inject(DestroyRef);
   public currentUser: any;
   public userId: string = '';
@@ -123,67 +123,10 @@ export class ThreadComponent implements OnInit {
   }
 
   /**
-   * Handles click events on mention buttons within a message.
-   * Determines whether a mention button was clicked and, if so,
-   * extracts its symbol (@ or #) and the associated name,
-   * then delegates to navigation logic.
-   *
-   * @param event - The MouseEvent triggered by the click.
+   * Delegates clicks inside the rendered message to the MentionService.
    */
   onMentionClick(event: MouseEvent | TouchEvent) {
-    const btn = (event.target as HTMLElement).closest('.tag-btn');
-    if (!btn) return;
-
-    const fullTag = btn.textContent?.trim();
-    if (!fullTag) return;
-
-    const symbol = fullTag.charAt(0);
-    const name = fullTag.slice(1).trim();
-    this.showProfileOrChannel(symbol, name);
-  }
-
-  /**
-   * Routes the click on a mention based on its symbol.
-   * If the symbol is '@', performs a user lookup;
-   * if '#', performs a channel lookup.
-   *
-   * @param symbol - The mention symbol, either '@' or '#'.
-   * @param name - The username or channel name to lookup.
-   */
-  async showProfileOrChannel(symbol: string, name: string) {
-    switch (symbol) {
-      case '@':
-        await this.caseUser(name);
-        break;
-
-      case '#':
-        await this.caseChannel(name);
-        break;
-    }
-  }
-
-  /**
-   * Looks up a user in Firestore by their full name,
-   * sets the navigation service’s receiver ID to the found user’s document ID,
-   * and switches the UI to a direct chat view.
-   *
-   * @param name - The user’s full name to query.
-   */
-  async caseUser(name: string) {
-    const user = await this.userStore.findUserByDisplayName(name);
-    if (user) this.navigationService.selectDirectMessageRecipient(user.id);
-  }
-
-  /**
-   * Looks up a channel in Firestore by its name,
-   * sets the navigation service’s receiver ID to the found channel’s document ID,
-   * and switches the UI to the channel view.
-   *
-   * @param name - The channel’s name to query.
-   */
-  async caseChannel(name: string) {
-    const channel = await this.channelService.findChannelByName(name);
-    if (channel?.id) this.navigationService.selectChannel(channel.id);
+    this.mentionService.handleMentionClick(event);
   }
 
   ngOnDestroy(): void {

--- a/src/app/features/app_chat/components/chat-thread/chat-thread.component.ts
+++ b/src/app/features/app_chat/components/chat-thread/chat-thread.component.ts
@@ -1,6 +1,7 @@
-import { Component, ElementRef, inject, OnInit, ViewChild } from '@angular/core';
+import { Component, DestroyRef, ElementRef, inject, OnInit, ViewChild } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { Firestore, collection, doc, getDoc, getDocs, onSnapshot, orderBy, query, where } from '@angular/fire/firestore';
 import { MatIconModule } from '@angular/material/icon';
@@ -36,6 +37,7 @@ export class ThreadComponent implements OnInit {
   public userService: UserService = inject(UserService);
   public authService = inject(AuthService);
   public navigationService: NavigationService = inject(NavigationService);
+  private readonly destroyRef = inject(DestroyRef);
   public currentUser: any;
   public userId: string = '';
   public currentChannel: any;
@@ -54,13 +56,13 @@ export class ThreadComponent implements OnInit {
    *
    * @type {() => void}
    */
-  unsubMessages!: () => void;
+  unsubMessages?: () => void;
 
   /**
    * OnInit lifecycle hook to set up query params and fetch data when component is initialized.
    */
   async ngOnInit() {
-    this.route.queryParams.subscribe(async (params) => {
+    this.route.queryParams.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(async (params) => {
       this.currentChannelId = params['reciverId'] || '';
       this.userId = params['currentUserId'] || '';
       this.parentMessageId = params['messageId'] || '';
@@ -118,14 +120,18 @@ export class ThreadComponent implements OnInit {
    * Retrieves the messages in the current thread.
    */
   private getMessages() {
+    this.unsubMessages?.();
+    this.unsubMessages = undefined;
+
     if (this.parentMessageId) {
       let threadRef = collection(this.firestore, `channels/${this.currentChannelId}/messages/${this.parentMessageId}/thread`);
       let threadQuery = query(threadRef, orderBy('timestamp', 'asc'));
 
-      onSnapshot(threadQuery, (snapshot) => {
+      this.unsubMessages = onSnapshot(threadQuery, (snapshot) => {
         this.messages = this.messagesService.processData(snapshot);
-        // this.userService.scrollToBottom(this.chatContentRef.nativeElement);
       });
+    } else {
+      this.messages = [];
     }
   }
 

--- a/src/app/features/app_chat/components/chat-thread/chat-thread.component.ts
+++ b/src/app/features/app_chat/components/chat-thread/chat-thread.component.ts
@@ -3,7 +3,6 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { Firestore, collection, doc, getDoc, getDocs, onSnapshot, orderBy, query, where } from '@angular/fire/firestore';
 import { MatIconModule } from '@angular/material/icon';
 
 import { ChatHeaderComponent } from '../chat-header/chat-header.component';
@@ -33,9 +32,8 @@ import { ChannelService } from '../../../app_channel/services/channel/channel.se
 })
 export class ThreadComponent implements OnInit {
   @ViewChild('chat') chatContentRef!: ElementRef;
-  private firestore: Firestore = inject(Firestore);
   private route: ActivatedRoute = inject(ActivatedRoute);
-  private messagesService: MessagesService = inject(MessagesService);
+  public messagesService: MessagesService = inject(MessagesService);
   public userService: UserService = inject(UserService);
   public authService = inject(AuthService);
   public navigationService: NavigationService = inject(NavigationService);
@@ -44,7 +42,6 @@ export class ThreadComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
   public currentUser: any;
   public userId: string = '';
-  public currentChannel: any;
   public currentChannelId: string = '';
   public parentMessageId: string = '';
   public inputEdit: string = '';
@@ -52,7 +49,6 @@ export class ThreadComponent implements OnInit {
   public editingMessageId: number | null = null;
   public listOpen: boolean = false;
   public isEditing: boolean = false;
-  public messages: any = [];
   public reactions: any = [];
 
   /**
@@ -71,7 +67,6 @@ export class ThreadComponent implements OnInit {
       this.userId = params['currentUserId'] || '';
       this.parentMessageId = params['messageId'] || '';
 
-      await this.getCurrentChannel();
       this.getThreadParentMessage();
       this.getMessages();
       this.currentUser = this.authService.currentUser();
@@ -79,28 +74,14 @@ export class ThreadComponent implements OnInit {
   }
 
   /**
-   * Fetches the current channel information from Firestore.
-   */
-  private async getCurrentChannel() {
-    if (this.currentChannelId) {
-      let channelRef = doc(this.firestore, `channels/${this.currentChannelId}`);
-      let channelRefDocSnap = await getDoc(channelRef);
-      channelRefDocSnap.exists() ? (this.currentChannel = channelRefDocSnap.data()) : null;
-    }
-  }
-
-  /**
    * Fetches the parent message details for the thread.
    */
   private async getThreadParentMessage() {
     if (this.parentMessageId) {
-      let parentMessageDocRef = doc(this.firestore, `channels/${this.currentChannelId}/messages/${this.parentMessageId}`);
-      let parentMessageDocSnap = await getDoc(parentMessageDocRef);
-
-      if (parentMessageDocSnap.exists()) {
-        let data = parentMessageDocSnap.data();
-        this.setParentMessageData(data);
-      }
+      const data = await this.messagesService.getParentMessage(this.currentChannelId, this.parentMessageId);
+      if (data) this.setParentMessageData(data);
+    } else {
+      this.parentMessageData = null;
     }
   }
 
@@ -128,14 +109,9 @@ export class ThreadComponent implements OnInit {
     this.unsubMessages = undefined;
 
     if (this.parentMessageId) {
-      let threadRef = collection(this.firestore, `channels/${this.currentChannelId}/messages/${this.parentMessageId}/thread`);
-      let threadQuery = query(threadRef, orderBy('timestamp', 'asc'));
-
-      this.unsubMessages = onSnapshot(threadQuery, (snapshot) => {
-        this.messages = this.messagesService.processData(snapshot);
-      });
+      this.unsubMessages = this.messagesService.subToThreadMessages(this.currentChannelId, this.parentMessageId);
     } else {
-      this.messages = [];
+      this.messagesService.threadMessages.set([]);
     }
   }
 
@@ -214,5 +190,6 @@ export class ThreadComponent implements OnInit {
     if (this.unsubMessages) {
       this.unsubMessages();
     }
+    this.messagesService.threadMessages.set([]);
   }
 }

--- a/src/app/features/app_chat/components/contactbar/contactbar.component.ts
+++ b/src/app/features/app_chat/components/contactbar/contactbar.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, inject, OnDestroy, OnInit } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
@@ -22,7 +22,7 @@ import { ProfileStatusComponent } from '../../../../shared/components/profile-st
   templateUrl: './contactbar.component.html',
   styleUrl: './contactbar.component.scss',
 })
-export class ContactbarComponent implements OnInit, OnDestroy {
+export class ContactbarComponent implements OnInit {
   public firestoreService = inject(FireServiceService);
   public navigationService: NavigationService = inject(NavigationService);
   public searchService: SearchService = inject(SearchService);
@@ -37,15 +37,13 @@ export class ContactbarComponent implements OnInit, OnDestroy {
   public currentLink: string = '';
   public addChannelWindow: boolean = false;
 
-  private unsubUsers?: any;
-  private unsubChannels?: any;
-
   /**
-   * Initializes the component by loading users, channels, and setting the current user.
+   * Initializes the component by ensuring the shared user and channel
+   * streams are running (owned by FireService, app-lifetime).
    */
-  async ngOnInit() {
-    this.unsubUsers = this.firestoreService.subAllUsers();
-    this.unsubChannels = this.firestoreService.subChannels();
+  ngOnInit() {
+    this.firestoreService.subAllUsers();
+    this.firestoreService.subChannels();
   }
 
   public toggleDropdown(type: 'channels' | 'directMessages') {
@@ -69,8 +67,4 @@ export class ContactbarComponent implements OnInit, OnDestroy {
     });
   }
 
-  ngOnDestroy() {
-    if (this.unsubUsers) this.unsubUsers();
-    if (this.unsubChannels) this.unsubChannels();
-  }
 }

--- a/src/app/features/app_chat/components/message/message-template.component.ts
+++ b/src/app/features/app_chat/components/message/message-template.component.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { Component, computed, inject, input, Input } from '@angular/core';
-import { UserService } from '../../../../shared/services/user/shared.service';
 import { FireServiceService } from '../../../../shared/services/firebase/fire-service.service';
 import { MatIconModule } from '@angular/material/icon';
 
@@ -12,7 +11,7 @@ import emojiData from 'unicode-emoji-json';
 
 import { LinkifyPipe } from '../../../pipes/linkify.pipe';
 import { UserStore } from '../../../../shared/services/user/user-store';
-import { ChannelService } from '../../../app_channel/services/channel/channel.service';
+import { MentionService } from '../../../../shared/services/mention/mention.service';
 
 import { DialogReciverComponent } from '../../../dialogs/dialog-reciver/dialog-reciver.component';
 import { ChannelMessage } from '../../models/channel-message/channel-message';
@@ -32,7 +31,7 @@ export class MessageTemplateComponent {
   private dialog = inject(MatDialog);
   public navigationService: NavigationService = inject(NavigationService);
   private userStore: UserStore = inject(UserStore);
-  private channelService: ChannelService = inject(ChannelService);
+  private mentionService: MentionService = inject(MentionService);
   menuOpen: boolean = false;
   reactionMenuOpen: boolean = false;
   reactionMenuOpenInFooter: boolean = false;
@@ -266,66 +265,9 @@ export class MessageTemplateComponent {
   }
 
   /**
-   * Handles click events on mention buttons within a message.
-   * Determines whether a mention button was clicked and, if so,
-   * extracts its symbol (@ or #) and the associated name,
-   * then delegates to navigation logic.
-   *
-   * @param event - The MouseEvent triggered by the click.
+   * Delegates clicks inside the rendered message to the MentionService.
    */
   onMentionClick(event: MouseEvent | TouchEvent) {
-    const btn = (event.target as HTMLElement).closest('.tag-btn');
-    if (!btn) return;
-
-    const fullTag = btn.textContent?.trim();
-    if (!fullTag) return;
-
-    const symbol = fullTag.charAt(0);
-    const name = fullTag.slice(1).trim();
-    this.showProfileOrChannel(symbol, name);
-  }
-
-  /**
-   * Routes the click on a mention based on its symbol.
-   * If the symbol is '@', performs a user lookup;
-   * if '#', performs a channel lookup.
-   *
-   * @param symbol - The mention symbol, either '@' or '#'.
-   * @param name - The username or channel name to lookup.
-   */
-  async showProfileOrChannel(symbol: string, name: string) {
-    switch (symbol) {
-      case '@':
-        await this.caseUser(name);
-        break;
-
-      case '#':
-        await this.caseChannel(name);
-        break;
-    }
-  }
-
-  /**
-   * Looks up a user in Firestore by their full name,
-   * sets the navigation service’s receiver ID to the found user’s document ID,
-   * and switches the UI to a direct chat view.
-   *
-   * @param name - The user’s full name to query.
-   */
-  async caseUser(name: string) {
-    const user = await this.userStore.findUserByDisplayName(name);
-    if (user) this.navigationService.selectDirectMessageRecipient(user.id);
-  }
-
-  /**
-   * Looks up a channel in Firestore by its name,
-   * sets the navigation service’s receiver ID to the found channel’s document ID,
-   * and switches the UI to the channel view.
-   *
-   * @param name - The channel’s name to query.
-   */
-  async caseChannel(name: string) {
-    const channel = await this.channelService.findChannelByName(name);
-    if (channel?.id) this.navigationService.selectChannel(channel.id);
+    this.mentionService.handleMentionClick(event);
   }
 }

--- a/src/app/features/app_chat/components/message/message-template.component.ts
+++ b/src/app/features/app_chat/components/message/message-template.component.ts
@@ -124,7 +124,7 @@ export class MessageTemplateComponent {
    * @param $event - The click event
    */
   public openThread(messageId: string) {
-    this.navigationService.goToThread(messageId);
+    this.navigationService.goToThread(messageId, this.currentChannelId);
   }
 
   /**

--- a/src/app/features/app_chat/components/message/message-template.component.ts
+++ b/src/app/features/app_chat/components/message/message-template.component.ts
@@ -7,12 +7,12 @@ import { MatIconModule } from '@angular/material/icon';
 import { FormsModule } from '@angular/forms';
 
 import { MatDialog } from '@angular/material/dialog';
-import { collection, getDocs, query, where } from '@firebase/firestore';
 import { NavigationService } from '../../../../shared/services/navigation/navigation.service';
 import emojiData from 'unicode-emoji-json';
 
-import { Firestore } from '@angular/fire/firestore';
 import { LinkifyPipe } from '../../../pipes/linkify.pipe';
+import { UserStore } from '../../../../shared/services/user/user-store';
+import { ChannelService } from '../../../app_channel/services/channel/channel.service';
 
 import { DialogReciverComponent } from '../../../dialogs/dialog-reciver/dialog-reciver.component';
 import { ChannelMessage } from '../../models/channel-message/channel-message';
@@ -31,7 +31,8 @@ export class MessageTemplateComponent {
   public authService = inject(AuthService);
   private dialog = inject(MatDialog);
   public navigationService: NavigationService = inject(NavigationService);
-  private firestore: Firestore = inject(Firestore);
+  private userStore: UserStore = inject(UserStore);
+  private channelService: ChannelService = inject(ChannelService);
   menuOpen: boolean = false;
   reactionMenuOpen: boolean = false;
   reactionMenuOpenInFooter: boolean = false;
@@ -259,22 +260,9 @@ export class MessageTemplateComponent {
    *          or null if no matching user is found.
    */
   private async _getReceiverByName(): Promise<User | null> {
-    const usersCollection = this.fireService.getCollectionRef('users');
     const searchName = this.message().name;
     if (!searchName) return null;
-
-    const q = query(usersCollection!, where('displayName', '==', searchName));
-    const querySnapshot = await getDocs(q);
-
-    if (!querySnapshot.empty) {
-      const doc = querySnapshot.docs[0];
-      const user = {
-        ...(doc.data() as Omit<User, 'id'>),
-        id: doc.id,
-      } as User;
-      return user;
-    }
-    return null;
+    return this.userStore.findUserByDisplayName(searchName);
   }
 
   /**
@@ -325,11 +313,8 @@ export class MessageTemplateComponent {
    * @param name - The user’s full name to query.
    */
   async caseUser(name: string) {
-    const usersRef = collection(this.firestore, 'users');
-    const q = query(usersRef, where('displayName', '==', name));
-    const snapshot = await getDocs(q);
-    const userDoc = snapshot.docs[0];
-    this.navigationService.selectDirectMessageRecipient(userDoc.id);
+    const user = await this.userStore.findUserByDisplayName(name);
+    if (user) this.navigationService.selectDirectMessageRecipient(user.id);
   }
 
   /**
@@ -340,10 +325,7 @@ export class MessageTemplateComponent {
    * @param name - The channel’s name to query.
    */
   async caseChannel(name: string) {
-    const channelsRef = collection(this.firestore, 'channels');
-    const q = query(channelsRef, where('name', '==', name));
-    const snapshot = await getDocs(q);
-    const channelDoc = snapshot.docs[0];
-    this.navigationService.selectChannel(channelDoc.id);
+    const channel = await this.channelService.findChannelByName(name);
+    if (channel?.id) this.navigationService.selectChannel(channel.id);
   }
 }

--- a/src/app/features/app_chat/main-chat/main-chat.component.html
+++ b/src/app/features/app_chat/main-chat/main-chat.component.html
@@ -23,7 +23,14 @@
         }
       </div>
 
-      <mat-drawer mode="side" #drawer position="end" class="thread-container">
+      <mat-drawer
+        #drawer
+        position="end"
+        class="thread-container"
+        [mode]="navigationService.isMobile() ? 'over' : 'side'"
+        [opened]="navigationService.isThreadOpen()"
+        (closedStart)="navigationService.toggleThread('close')"
+      >
         <app-thread></app-thread>
       </mat-drawer>
     </mat-drawer-container>

--- a/src/app/features/app_chat/services/messages/messages.service.ts
+++ b/src/app/features/app_chat/services/messages/messages.service.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable, signal } from '@angular/core';
-import { onSnapshot, orderBy, query, QuerySnapshot, serverTimestamp } from '@angular/fire/firestore';
+import { getDoc, onSnapshot, orderBy, query, QuerySnapshot } from '@angular/fire/firestore';
 import { FireServiceService } from '../../../../shared/services/firebase/fire-service.service';
 import { ChannelMessage } from '../../models/channel-message/channel-message';
 import { DirectMessage } from '../../models/direct-message/direct-message';
@@ -13,6 +13,7 @@ export class MessagesService {
   private readonly authService = inject(AuthService);
 
   public messages = signal<ChannelMessage[] | DirectMessage[]>([]);
+  public threadMessages = signal<(ChannelMessage | DirectMessage)[]>([]);
 
   public subToMessages(channelId: string | null) {
     if (!channelId) return () => {};
@@ -24,6 +25,31 @@ export class MessagesService {
     return onSnapshot(messagesQuery, (snapshot) => {
       this.messages.set(this.processData(snapshot));
     });
+  }
+
+  /**
+   * Streams the replies of a thread into the threadMessages signal.
+   * @returns The unsubscribe function of the listener.
+   */
+  public subToThreadMessages(channelId: string, parentMessageId: string): () => void {
+    const threadRef = this.fireService.getCollectionRef(`channels/${channelId}/messages/${parentMessageId}/thread`);
+    if (!threadRef) return () => {};
+
+    const threadQuery = query(threadRef, orderBy('timestamp', 'asc'));
+    return onSnapshot(threadQuery, (snapshot) => {
+      this.threadMessages.set(this.processData(snapshot));
+    });
+  }
+
+  /**
+   * Fetches the parent message of a thread once.
+   */
+  public async getParentMessage(channelId: string, messageId: string): Promise<any | null> {
+    const messageRef = this.fireService.getMessageRef(channelId, messageId);
+    if (!messageRef) return null;
+
+    const snap = await getDoc(messageRef);
+    return snap.exists() ? { id: snap.id, ...snap.data() } : null;
   }
 
   public subToConversationMessages(userA: string, userB: string): () => void {

--- a/src/app/features/dialogs/avatar-selection/avatar-selection/avatar-selection.component.html
+++ b/src/app/features/dialogs/avatar-selection/avatar-selection/avatar-selection.component.html
@@ -6,17 +6,10 @@
     <h1>Wähle deinen Avatar</h1>
   </div>
 
-  <img class="profile-img" [src]="selectedAvatar" alt="Avatar Bild" />
+  <img class="profile-img" [src]="selectedAvatar()" alt="Avatar Bild" />
   <p class="name">{{ data?.user?.displayName }}</p>
 
   <p class="align-base">Aus der Liste wählen</p>
-  <div class="container">
-    <img (click)="setAvatar('img/avatars/avatar_1.png')" src="img/avatars/avatar_1.png" alt="bilder" />
-    <img (click)="setAvatar('img/avatars/avatar_2.png')" src="img/avatars/avatar_2.png" alt="bilder" />
-    <img (click)="setAvatar('img/avatars/avatar_3.png')" src="img/avatars/avatar_3.png" alt="bilder" />
-    <img (click)="setAvatar('img/avatars/avatar_4.png')" src="img/avatars/avatar_4.png" alt="bilder" />
-    <img (click)="setAvatar('img/avatars/avatar_5.png')" src="img/avatars/avatar_5.png" alt="bilder" />
-    <img (click)="setAvatar('img/avatars/avatar_6.png')" src="img/avatars/avatar_6.png" alt="bilder" />
-  </div>
+  <app-avatar-picker [(selected)]="selectedAvatar"></app-avatar-picker>
   <button (click)="onSave()">Weiter</button>
 </div>

--- a/src/app/features/dialogs/avatar-selection/avatar-selection/avatar-selection.component.ts
+++ b/src/app/features/dialogs/avatar-selection/avatar-selection/avatar-selection.component.ts
@@ -1,36 +1,19 @@
-import { AfterViewInit, Component, inject, Inject } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatIcon } from '@angular/material/icon';
-import { NavigationService } from '../../../../shared/services/navigation/navigation.service';
-
+import { AvatarPickerComponent } from '../../../../shared/components/avatar-picker/avatar-picker.component';
 
 @Component({
   selector: 'app-avatar-selection',
-  imports: [MatIcon],
+  imports: [MatIcon, AvatarPickerComponent],
   templateUrl: './avatar-selection.component.html',
   styleUrl: './avatar-selection.component.scss',
 })
-export class AvatarSelectionComponent implements AfterViewInit {
-  public navigationService = inject(NavigationService);
+export class AvatarSelectionComponent {
+  public readonly dialogRef = inject(MatDialogRef<AvatarSelectionComponent>);
+  public readonly data = inject<any>(MAT_DIALOG_DATA);
 
-  constructor(public dialogRef: MatDialogRef<AvatarSelectionComponent>, @Inject(MAT_DIALOG_DATA) public data: any) {}
-  public selectedAvatar: string = '';
-
-  /**
-   * Lifecycle hook that runs after the component's view has been fully initialized.
-   * Sets the initially selected avatar based on the user's current photoURL.
-   */
-  ngAfterViewInit() {
-    this.selectedAvatar = this.data?.user?.photoURL;
-  }
-
-  /**
-   * Updates the currently selected avatar.
-   * @param avatar - The URL or identifier of the avatar to be selected.
-   */
-  setAvatar(avatar: string) {
-    this.selectedAvatar = avatar;
-  }
+  public selectedAvatar = signal<string>(this.data?.user?.photoUrl || this.data?.user?.photoURL || '');
 
   /**
    * Closes the dialog without saving any changes.
@@ -43,6 +26,6 @@ export class AvatarSelectionComponent implements AfterViewInit {
    * Closes the dialog and returns the selected avatar to the calling component.
    */
   onSave() {
-    this.dialogRef.close(this.selectedAvatar);
+    this.dialogRef.close(this.selectedAvatar());
   }
 }

--- a/src/app/shared/components/avatar-picker/avatar-picker.component.html
+++ b/src/app/shared/components/avatar-picker/avatar-picker.component.html
@@ -1,0 +1,5 @@
+<div class="avatar-picker">
+  @for (avatar of avatars; track avatar) {
+    <img [src]="avatar" [alt]="avatar" (click)="selected.set(avatar)" [class.selected]="selected() === avatar" />
+  }
+</div>

--- a/src/app/shared/components/avatar-picker/avatar-picker.component.scss
+++ b/src/app/shared/components/avatar-picker/avatar-picker.component.scss
@@ -1,0 +1,29 @@
+.avatar-picker {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  width: 100%;
+  gap: 8px;
+
+  > img {
+    width: clamp(40px, 12vw, 64px);
+    aspect-ratio: 1 / 1;
+    height: auto;
+    border-radius: 50%;
+    object-fit: cover;
+    cursor: pointer;
+    transition: transform 0.125s ease-in-out;
+
+    &:hover {
+      transform: scale(1.1);
+    }
+
+    &.selected {
+      transform: scale(1.1);
+    }
+
+    &:hover:not(.selected) {
+      opacity: 0.8;
+    }
+  }
+}

--- a/src/app/shared/components/avatar-picker/avatar-picker.component.ts
+++ b/src/app/shared/components/avatar-picker/avatar-picker.component.ts
@@ -1,0 +1,16 @@
+import { Component, model } from '@angular/core';
+import { AVATAR_IMAGES } from '../../constants';
+
+/**
+ * Shared avatar grid used by the registration step and the
+ * profile dialog; exposes the selection as a two-way model.
+ */
+@Component({
+  selector: 'app-avatar-picker',
+  templateUrl: './avatar-picker.component.html',
+  styleUrl: './avatar-picker.component.scss',
+})
+export class AvatarPickerComponent {
+  public readonly avatars = AVATAR_IMAGES;
+  public selected = model<string>('');
+}

--- a/src/app/shared/constants.ts
+++ b/src/app/shared/constants.ts
@@ -1,1 +1,5 @@
 export const CONTACT_EMAIL = 'gianniskarakasidhs@hotmail.com';
+
+export const DEFAULT_CHANNEL_ID = 'KqvcY68R1jP2UsQkv6Nz';
+
+export const GUEST_EMAIL = 'gast@portfolio.de';

--- a/src/app/shared/constants.ts
+++ b/src/app/shared/constants.ts
@@ -3,3 +3,14 @@ export const CONTACT_EMAIL = 'gianniskarakasidhs@hotmail.com';
 export const DEFAULT_CHANNEL_ID = 'KqvcY68R1jP2UsQkv6Nz';
 
 export const GUEST_EMAIL = 'gast@portfolio.de';
+
+export const DEFAULT_AVATAR = 'img/avatars/avatar_default.png';
+
+export const AVATAR_IMAGES = [
+  'img/avatars/avatar_1.png',
+  'img/avatars/avatar_2.png',
+  'img/avatars/avatar_3.png',
+  'img/avatars/avatar_4.png',
+  'img/avatars/avatar_5.png',
+  'img/avatars/avatar_6.png',
+];

--- a/src/app/shared/services/firebase/fire-service.service.ts
+++ b/src/app/shared/services/firebase/fire-service.service.ts
@@ -18,6 +18,7 @@ import { ChannelMessage } from '../../../features/app_chat/models/channel-messag
 import { User } from '../../../features/app_auth/models/user/user';
 import { Channel } from '../../../features/app_channel/models/channel/channel';
 import { AuthService } from '../../../features/app_auth/services/auth/auth.service';
+import { DEFAULT_CHANNEL_ID, GUEST_EMAIL } from '../../constants';
 
 @Injectable({
   providedIn: 'root',
@@ -93,11 +94,10 @@ export class FireServiceService {
     const authService = this.injector.get(AuthService);
     const channels: Channel[] = this._allChannels();
     const currentUser = authService.currentUser();
-    const DEFAULT_CHANNEL_ID = 'KqvcY68R1jP2UsQkv6Nz';
 
     if (!currentUser) return [];
 
-    const isGuest = currentUser.email === 'gast@portfolio.de';
+    const isGuest = currentUser.email === GUEST_EMAIL;
     return channels.filter((channel) => {
       if (isGuest) {
         return channel.id === DEFAULT_CHANNEL_ID || channel.createdBy === currentUser.id;

--- a/src/app/shared/services/firebase/fire-service.service.ts
+++ b/src/app/shared/services/firebase/fire-service.service.ts
@@ -1,4 +1,4 @@
-import { computed, inject, Injectable, Injector, signal } from '@angular/core';
+import { computed, inject, Injectable, signal } from '@angular/core';
 import {
   addDoc,
   arrayRemove,
@@ -17,15 +17,15 @@ import {
 import { ChannelMessage } from '../../../features/app_chat/models/channel-message/channel-message';
 import { User } from '../../../features/app_auth/models/user/user';
 import { Channel } from '../../../features/app_channel/models/channel/channel';
-import { AuthService } from '../../../features/app_auth/services/auth/auth.service';
 import { DEFAULT_CHANNEL_ID, GUEST_EMAIL } from '../../constants';
+import { UserStore } from '../user/user-store';
 
 @Injectable({
   providedIn: 'root',
 })
 export class FireServiceService {
   private firestore: Firestore = inject(Firestore);
-  private injector = inject(Injector);
+  private userStore = inject(UserStore);
   public allUsers = signal<User[]>([]);
   private _allChannels = signal<any[]>([]);
   private unsubAllUsers?: () => void;
@@ -91,9 +91,8 @@ export class FireServiceService {
   }
 
   public myChannels = computed(() => {
-    const authService = this.injector.get(AuthService);
     const channels: Channel[] = this._allChannels();
-    const currentUser = authService.currentUser();
+    const currentUser = this.userStore.currentUser();
 
     if (!currentUser) return [];
 

--- a/src/app/shared/services/firebase/fire-service.service.ts
+++ b/src/app/shared/services/firebase/fire-service.service.ts
@@ -27,6 +27,8 @@ export class FireServiceService {
   private injector = inject(Injector);
   public allUsers = signal<User[]>([]);
   private _allChannels = signal<any[]>([]);
+  private unsubAllUsers?: () => void;
+  private unsubChannels?: () => void;
 
   /**
    * Updates the online status of the current user in Firestore.
@@ -45,11 +47,14 @@ export class FireServiceService {
   /**
    * Erstellt eine permanente Verbindung zur User-Collection.
    * Jede Änderung (Login/Logout/Neuer User) triggert das Signal sofort.
+   * Idempotent: der Listener lebt für die App-Lebensdauer, weitere Aufrufe
+   * sind No-ops (vorher entstand pro Aufruf ein neuer Listener).
    */
-  public subAllUsers() {
+  public subAllUsers(): void {
+    if (this.unsubAllUsers) return;
     const usersCollection = collection(this.firestore, 'users');
 
-    return onSnapshot(
+    this.unsubAllUsers = onSnapshot(
       usersCollection,
       (snapshot) => {
         const users = snapshot.docs.map(
@@ -68,12 +73,14 @@ export class FireServiceService {
   }
 
   /**
-   * Startet den Echtzeit-Stream für alle Channels
+   * Startet den Echtzeit-Stream für alle Channels.
+   * Idempotent wie subAllUsers().
    */
-  public subChannels() {
+  public subChannels(): void {
+    if (this.unsubChannels) return;
     const channelRef = collection(this.firestore, 'channels');
 
-    return onSnapshot(channelRef, (snapshot) => {
+    this.unsubChannels = onSnapshot(channelRef, (snapshot) => {
       const data = snapshot.docs.map((doc) => ({
         id: doc.id,
         ...doc.data(),

--- a/src/app/shared/services/mention/mention.service.ts
+++ b/src/app/shared/services/mention/mention.service.ts
@@ -1,0 +1,51 @@
+import { inject, Injectable } from '@angular/core';
+import { NavigationService } from '../navigation/navigation.service';
+import { UserStore } from '../user/user-store';
+import { ChannelService } from '../../../features/app_channel/services/channel/channel.service';
+
+/**
+ * Handles clicks on @user and #channel mentions rendered inside
+ * messages (shared by channel messages and thread replies).
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class MentionService {
+  private readonly userStore = inject(UserStore);
+  private readonly channelService = inject(ChannelService);
+  private readonly navigationService = inject(NavigationService);
+
+  /**
+   * Inspects a click inside a rendered message and, if a mention chip
+   * (.tag-btn) was hit, navigates to the mentioned user or channel.
+   */
+  public handleMentionClick(event: MouseEvent | TouchEvent): void {
+    const btn = (event.target as HTMLElement).closest('.tag-btn');
+    if (!btn) return;
+
+    const fullTag = btn.textContent?.trim();
+    if (!fullTag) return;
+
+    const symbol = fullTag.charAt(0);
+    const name = fullTag.slice(1).trim();
+    this.navigateToMention(symbol, name);
+  }
+
+  /**
+   * Navigates to a mentioned user ('@') or channel ('#') by name.
+   */
+  public async navigateToMention(symbol: string, name: string): Promise<void> {
+    switch (symbol) {
+      case '@': {
+        const user = await this.userStore.findUserByDisplayName(name);
+        if (user) this.navigationService.selectDirectMessageRecipient(user.id);
+        break;
+      }
+      case '#': {
+        const channel = await this.channelService.findChannelByName(name);
+        if (channel?.id) this.navigationService.selectChannel(channel.id);
+        break;
+      }
+    }
+  }
+}

--- a/src/app/shared/services/navigation/navigation.service.ts
+++ b/src/app/shared/services/navigation/navigation.service.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable, signal } from '@angular/core';
-import { BehaviorSubject, distinctUntilChanged, filter, fromEvent, map, startWith, Subject, Subscription } from 'rxjs';
+import { distinctUntilChanged, filter, fromEvent, map } from 'rxjs';
 import { NavigationEnd, Router } from '@angular/router';
 
 @Injectable({
@@ -8,17 +8,13 @@ import { NavigationEnd, Router } from '@angular/router';
 export class NavigationService {
   private router = inject(Router);
 
-  private screenWidthSubject = new BehaviorSubject<boolean>(this.checkScreenWidth());
-  screenWidth$ = this.screenWidthSubject.asObservable();
-  private screenWidthSubscription?: Subscription;
-  private resizeSubscription?: Subscription;
-
   public isAuthPage = signal<boolean>(true);
   public isContactbarPage = signal<boolean>(true);
   public isMainChat = signal<boolean>(true);
   public isMobile = signal<boolean>(this.checkScreenWidth());
   public isChannelsOpen = signal<boolean>(true); // Default offen
   public isDirectMessagesOpen = signal<boolean>(false);
+  public isThreadOpen = signal<boolean>(false);
 
   /**
    * The constructor sets up observables for screen width changes, subscribes to route query parameters,
@@ -48,8 +44,16 @@ export class NavigationService {
     }
   }
 
-  public goToThread(id: string) {
-    console.log(id);
+  /**
+   * Opens the thread panel for a message by putting its id into the query
+   * params (read by ThreadComponent) and opening the thread drawer.
+   */
+  public goToThread(messageId: string, channelId: string) {
+    this.isThreadOpen.set(true);
+    this.router.navigate([], {
+      queryParams: { messageId: messageId, reciverId: channelId },
+      queryParamsHandling: 'merge',
+    });
   }
 
   public goToLogin() {
@@ -68,6 +72,7 @@ export class NavigationService {
       this.isDirectMessagesOpen.set(true);
       this.isChannelsOpen.set(false);
     }
+    this.isThreadOpen.set(url.includes('messageId='));
     const isAuth = url.includes('login') || url.includes('register');
     const isContactbar = url.includes('contactbar');
     const path = url.split('?')[0];
@@ -78,10 +83,12 @@ export class NavigationService {
   }
 
   public selectChannel(id: string) {
+    this.isThreadOpen.set(false);
     this.router.navigate(['/main/channel', id]);
   }
 
   public selectDirectMessageRecipient(id: string) {
+    this.isThreadOpen.set(false);
     this.router.navigate(['/main/direct', id]);
   }
 
@@ -93,7 +100,7 @@ export class NavigationService {
     this.router.navigate(['/main/new-message']);
   }
   /**
-   * Observes screen width changes and updates the screenWidthSubject.
+   * Observes screen width changes and updates the isMobile signal.
    */
   private observeScreenWidth(): void {
     fromEvent(window, 'resize')
@@ -117,5 +124,19 @@ export class NavigationService {
     return window.innerWidth < 1024;
   }
 
-  public toggleThread(a: any) {}
+  /**
+   * Opens or closes the thread drawer; closing also removes the messageId
+   * query param so a reload does not restore a stale thread.
+   */
+  public toggleThread(action: 'open' | 'close') {
+    if (action === 'close') {
+      this.isThreadOpen.set(false);
+      this.router.navigate([], {
+        queryParams: { messageId: null },
+        queryParamsHandling: 'merge',
+      });
+    } else {
+      this.isThreadOpen.set(true);
+    }
+  }
 }

--- a/src/app/shared/services/user/user-store.ts
+++ b/src/app/shared/services/user/user-store.ts
@@ -1,4 +1,5 @@
-import { Injectable, signal } from '@angular/core';
+import { inject, Injectable, signal } from '@angular/core';
+import { collection, Firestore, getDocs, query, where } from '@angular/fire/firestore';
 import { User } from '../../../features/app_auth/models/user/user';
 
 /**
@@ -10,10 +11,23 @@ import { User } from '../../../features/app_auth/models/user/user';
   providedIn: 'root',
 })
 export class UserStore {
+  private readonly firestore = inject(Firestore);
+
   private readonly _currentUser = signal<User | null>(null);
   public readonly currentUser = this._currentUser.asReadonly();
 
   public setCurrentUser(user: User | null): void {
     this._currentUser.set(user);
+  }
+
+  /**
+   * Looks up a user document by its displayName (used for @mentions).
+   */
+  public async findUserByDisplayName(displayName: string): Promise<User | null> {
+    const usersRef = collection(this.firestore, 'users');
+    const q = query(usersRef, where('displayName', '==', displayName));
+    const snapshot = await getDocs(q);
+    const docSnap = snapshot.docs[0];
+    return docSnap ? ({ ...(docSnap.data() as Omit<User, 'id'>), id: docSnap.id } as User) : null;
   }
 }

--- a/src/app/shared/services/user/user-store.ts
+++ b/src/app/shared/services/user/user-store.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable, signal } from '@angular/core';
-import { collection, Firestore, getDocs, query, where } from '@angular/fire/firestore';
+import { collection, doc, Firestore, getDoc, getDocs, query, where } from '@angular/fire/firestore';
 import { User } from '../../../features/app_auth/models/user/user';
 
 /**
@@ -18,6 +18,15 @@ export class UserStore {
 
   public setCurrentUser(user: User | null): void {
     this._currentUser.set(user);
+  }
+
+  /**
+   * Fetches a user document by its id.
+   */
+  public async getUserById(id: string): Promise<User | null> {
+    if (!id) return null;
+    const snap = await getDoc(doc(this.firestore, 'users', id));
+    return snap.exists() ? ({ ...(snap.data() as Omit<User, 'id'>), id: snap.id } as User) : null;
   }
 
   /**

--- a/src/app/shared/services/user/user-store.ts
+++ b/src/app/shared/services/user/user-store.ts
@@ -1,0 +1,19 @@
+import { Injectable, signal } from '@angular/core';
+import { User } from '../../../features/app_auth/models/user/user';
+
+/**
+ * Holds the authenticated user's data. AuthService writes to it,
+ * everyone else (FireService, components) reads the signal — this
+ * breaks the former FireService <-> AuthService injection cycle.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class UserStore {
+  private readonly _currentUser = signal<User | null>(null);
+  public readonly currentUser = this._currentUser.asReadonly();
+
+  public setCurrentUser(user: User | null): void {
+    this._currentUser.set(user);
+  }
+}

--- a/src/core/auth.guard.ts
+++ b/src/core/auth.guard.ts
@@ -4,9 +4,11 @@ import { CanActivateFn, Router } from '@angular/router';
 
 export const authGuard: CanActivateFn = (route, state) => {
   const router = inject(Router);
+  const auth = inject(Auth);
 
   return new Promise((resolve) => {
-    onAuthStateChanged(inject(Auth), (user) => {
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      unsubscribe();
       if (user) {
         resolve(true);
       } else {


### PR DESCRIPTION
Setzt **Phase 6 der Refactoring-Roadmap** um (stacked auf #17; Merge-Reihenfolge #11 → #14 → #15 → #16 → #17 → dieser PR).

### Änderungen (je 1 Commit)
- **MentionService** (`shared/services/mention/`): der wortgleiche Mention-Klick-Code aus message-template und chat-thread existiert jetzt genau einmal; beide Komponenten delegieren (−123 Zeilen)
- **AvatarPickerComponent** (`shared/components/avatar-picker/`): das duplizierte Avatar-Grid aus Registrierungs-Seite und Profil-Dialog ist eine gemeinsame Komponente mit two-way `model()`-Signal; Avatar-Liste in `shared/constants.ts`
- **Auth-Form-Factories**: `createLoginForm`/`createRegisterForm` sind reine Factory-Funktionen in `app_auth/forms/`; AuthService hängt nicht mehr an FormBuilder (SRP)

### Bewusst verschoben
Die Trennung des SearchService (UI-State vs. Suchlogik) ist auf einen Folge-PR verschoben — sie berührt Templates von vier Komponenten und würde diesen Diff dominieren.

### Verifikation
`ng build` grün nach jedem Commit. Smoke-Test: Mentions in Channel-Nachricht UND Thread-Antwort; Avatar-Auswahl bei Registrierung und im Profil-Dialog; Login/Registrierung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)