### PR TITLE
Phase 7: message-template zerlegen, Typisierung, Signal-Inputs & OnPush

### DIFF
--- a/src/app/features/app_chat/components/divider/divider-template.component.ts
+++ b/src/app/features/app_chat/components/divider/divider-template.component.ts
@@ -1,10 +1,11 @@
-import { Component, computed, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 
 @Component({
   selector: 'app-divider-template',
   imports: [],
   templateUrl: './divider-template.component.html',
   styleUrl: './divider-template.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DividerTemplateComponent {
   messageData = input.required<Date | any>();

--- a/src/app/features/app_chat/components/message/message-reactions/message-reactions.component.html
+++ b/src/app/features/app_chat/components/message/message-reactions/message-reactions.component.html
@@ -25,19 +25,19 @@
     </div>
   }
 
-  @if (hiddenCount() > 0 && !showAllReactions) {
-    <button class="emoji-box" (click)="showAllReactions = true">{{ hiddenCount() }} weitere</button>
+  @if (hiddenCount() > 0 && !showAllReactions()) {
+    <button class="emoji-box" (click)="showAllReactions.set(true)">{{ hiddenCount() }} weitere</button>
   }
-  @if (showAllReactions && reactions().length > visibleLimit()) {
-    <button class="emoji-box" (click)="showAllReactions = false">Weniger anzeigen</button>
+  @if (showAllReactions() && reactions().length > visibleLimit()) {
+    <button class="emoji-box" (click)="showAllReactions.set(false)">Weniger anzeigen</button>
   }
   @if (reactions().length > 0) {
-    <button (click)="reactionMenuOpen = !reactionMenuOpen" class="hover-to-dark-purple">
+    <button (click)="reactionMenuOpen.set(!reactionMenuOpen())" class="hover-to-dark-purple">
       <mat-icon class="material-symbols-outlined"> add_reaction </mat-icon>
     </button>
   }
 
-  @if (reactionMenuOpen) {
+  @if (reactionMenuOpen()) {
     <div class="reaction-menu">
       @for (emoji of preSelectedEmojiList; track $index) {
         <button

--- a/src/app/features/app_chat/components/message/message-reactions/message-reactions.component.html
+++ b/src/app/features/app_chat/components/message/message-reactions/message-reactions.component.html
@@ -1,0 +1,53 @@
+<div class="emoji-container">
+  @for (reaction of visibleReactions(); track reaction.emoji) {
+    @let names = reactionsService.getReactionNamesForEmoji(reaction.emoji, reactions());
+    <div
+      (click)="toggle(reaction.emoji)"
+      [ngClass]="{ 'bg-purple': reactionsService.hasReacted(reaction.emoji, reactions()) }"
+      class="emoji-box"
+    >
+      <span>{{ reaction.emoji }}</span>
+      <span>{{ reactionsService.countEmoji(reaction.emoji, reactions()) }}</span>
+      <div class="reaction-from-dialog">
+        <span>{{ reaction.emoji }}</span>
+        @for (name of names; track $index) {
+          <h3 class="font-weight-700">{{ name }}</h3>
+        }
+        @if (names.length > 1) {
+          <span>haben</span>
+        } @else if (names.length === 1 && names[0] === "Du") {
+          <span>hast</span>
+        } @else if (names.length === 1) {
+          <span>hat</span>
+        }
+        <span> reagiert</span>
+      </div>
+    </div>
+  }
+
+  @if (hiddenCount() > 0 && !showAllReactions) {
+    <button class="emoji-box" (click)="showAllReactions = true">{{ hiddenCount() }} weitere</button>
+  }
+  @if (showAllReactions && reactions().length > visibleLimit()) {
+    <button class="emoji-box" (click)="showAllReactions = false">Weniger anzeigen</button>
+  }
+  @if (reactions().length > 0) {
+    <button (click)="reactionMenuOpen = !reactionMenuOpen" class="hover-to-dark-purple">
+      <mat-icon class="material-symbols-outlined"> add_reaction </mat-icon>
+    </button>
+  }
+
+  @if (reactionMenuOpen) {
+    <div class="reaction-menu">
+      @for (emoji of preSelectedEmojiList; track $index) {
+        <button
+          class="btn-secundary circle"
+          [ngClass]="{ 'bg-purple': reactionsService.hasReacted(emoji, reactions()) }"
+          (click)="toggle(emoji)"
+        >
+          {{ emoji }}
+        </button>
+      }
+    </div>
+  }
+</div>

--- a/src/app/features/app_chat/components/message/message-reactions/message-reactions.component.scss
+++ b/src/app/features/app_chat/components/message/message-reactions/message-reactions.component.scss
@@ -1,0 +1,98 @@
+button {
+  border: none;
+  outline: none;
+  background-color: unset;
+  white-space: nowrap;
+  transition: all, 0.125s ease-in-out;
+  cursor: pointer;
+  color: black;
+}
+
+.emoji-container {
+  display: flex;
+  flex-wrap: wrap;
+  row-gap: 10px;
+  column-gap: 20px;
+  position: relative;
+}
+
+.emoji-box {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 5px 10px;
+  outline: 1px solid var(--light-purple);
+  border-radius: 20px;
+  background-color: white;
+
+  &:hover {
+    color: var(--medium-purple);
+    outline-color: var(--medium-purple);
+    .reaction-from-dialog {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+  }
+}
+
+.reaction-from-dialog {
+  display: none;
+  position: absolute;
+  bottom: 40px;
+  left: 32px;
+  align-items: center;
+  background-color: var(--dark-purple);
+  border-radius: 30px 30px 30px 0;
+  padding: 10px 15px;
+  color: white;
+  z-index: 10;
+  white-space: nowrap;
+  font-size: 16px;
+}
+
+.reaction-menu {
+  position: absolute;
+  bottom: 40px;
+  left: 94px;
+  display: flex;
+  justify-content: center;
+  gap: 4px;
+  width: max-content;
+  max-width: 300px;
+  max-height: 300px;
+  overflow-y: auto;
+  flex-wrap: wrap;
+  z-index: 10;
+  margin-top: 20px;
+  padding: 8px;
+  border: 1px solid var(--light-purple);
+  background-color: white;
+  border-radius: 25px 25px 25px 0;
+}
+
+:host-context(.message.reverse) .reaction-menu {
+  left: -120px;
+  border-radius: 25px 25px 0 25px;
+}
+
+.btn-secundary {
+  font-size: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2em;
+  height: 2em;
+  outline: none !important;
+
+  &:hover {
+    color: var(--dark-purple);
+    background-color: var(--bg-color);
+  }
+}
+
+.circle {
+  border-radius: 50%;
+}

--- a/src/app/features/app_chat/components/message/message-reactions/message-reactions.component.ts
+++ b/src/app/features/app_chat/components/message/message-reactions/message-reactions.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, computed, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, signal } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { ChannelMessage } from '../../../models/channel-message/channel-message';
 import { ReactionsService, ReactionContext } from '../../../services/reactions/reactions.service';
@@ -15,6 +15,7 @@ import { PRESELECTED_EMOJIS } from '../../../../../shared/constants';
   imports: [CommonModule, MatIconModule],
   templateUrl: './message-reactions.component.html',
   styleUrl: './message-reactions.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MessageReactionsComponent {
   public readonly reactionsService = inject(ReactionsService);
@@ -25,8 +26,8 @@ export class MessageReactionsComponent {
   public parentMessageId = input<string>('');
   public isThread = input<boolean>(false);
 
-  public showAllReactions = false;
-  public reactionMenuOpen = false;
+  public showAllReactions = signal(false);
+  public reactionMenuOpen = signal(false);
   public readonly preSelectedEmojiList = Object.values(PRESELECTED_EMOJIS);
 
   public reactions = computed(() => this.message().reaction ?? []);
@@ -36,7 +37,7 @@ export class MessageReactionsComponent {
 
   public visibleReactions = computed(() => {
     const unique = this.reactionsService.uniqueEmojis(this.reactions());
-    return this.showAllReactions ? unique : unique.slice(0, this.visibleLimit());
+    return this.showAllReactions() ? unique : unique.slice(0, this.visibleLimit());
   });
 
   public hiddenCount = computed(() => this.reactionsService.countUniqueEmojis(this.reactions()) - this.visibleLimit());
@@ -51,6 +52,6 @@ export class MessageReactionsComponent {
 
   public toggle(emoji: string): void {
     this.reactionsService.toggleReaction(this.message(), emoji, this.context());
-    this.reactionMenuOpen = false;
+    this.reactionMenuOpen.set(false);
   }
 }

--- a/src/app/features/app_chat/components/message/message-reactions/message-reactions.component.ts
+++ b/src/app/features/app_chat/components/message/message-reactions/message-reactions.component.ts
@@ -1,0 +1,56 @@
+import { CommonModule } from '@angular/common';
+import { Component, computed, inject, input } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+import { ChannelMessage } from '../../../models/channel-message/channel-message';
+import { ReactionsService, ReactionContext } from '../../../services/reactions/reactions.service';
+import { NavigationService } from '../../../../../shared/services/navigation/navigation.service';
+import { PRESELECTED_EMOJIS } from '../../../../../shared/constants';
+
+/**
+ * Renders the emoji reactions of a message (footer) including the
+ * hover tooltip with reacting users and the quick reaction menu.
+ */
+@Component({
+  selector: 'app-message-reactions',
+  imports: [CommonModule, MatIconModule],
+  templateUrl: './message-reactions.component.html',
+  styleUrl: './message-reactions.component.scss',
+})
+export class MessageReactionsComponent {
+  public readonly reactionsService = inject(ReactionsService);
+  public readonly navigationService = inject(NavigationService);
+
+  public message = input.required<ChannelMessage>();
+  public currentChannelId = input<string>('');
+  public parentMessageId = input<string>('');
+  public isThread = input<boolean>(false);
+
+  public showAllReactions = false;
+  public reactionMenuOpen = false;
+  public readonly preSelectedEmojiList = Object.values(PRESELECTED_EMOJIS);
+
+  public reactions = computed(() => this.message().reaction ?? []);
+
+  /** How many reaction chips are shown before collapsing behind 'weitere'. */
+  public visibleLimit = computed(() => (this.navigationService.isMobile() ? 2 : 20));
+
+  public visibleReactions = computed(() => {
+    const unique = this.reactionsService.uniqueEmojis(this.reactions());
+    return this.showAllReactions ? unique : unique.slice(0, this.visibleLimit());
+  });
+
+  public hiddenCount = computed(() => this.reactionsService.countUniqueEmojis(this.reactions()) - this.visibleLimit());
+
+  private context(): ReactionContext {
+    return {
+      channelId: this.currentChannelId(),
+      parentMessageId: this.parentMessageId(),
+      isThread: this.isThread(),
+    };
+  }
+
+  public toggle(emoji: string): void {
+    this.reactionsService.toggleReaction(this.message(), emoji, this.context());
+    this.reactionMenuOpen = false;
+  }
+}

--- a/src/app/features/app_chat/components/message/message-template.component.html
+++ b/src/app/features/app_chat/components/message/message-template.component.html
@@ -5,7 +5,7 @@
     reverse: isOwnMessage(),
   }"
 >
-  @if (!isEditing && channelType !== "direct") {
+  @if (!isEditing && channelType() !== "direct") {
     <div class="reaction-bar">
       <button
         class="btn-secundary"
@@ -24,7 +24,7 @@
       <button (click)="this.reactionMenuOpen = !this.reactionMenuOpen" class="btn-secundary">
         <mat-icon class="material-symbols-outlined"> add_reaction </mat-icon>
       </button>
-      @if (!isThread) {
+      @if (!isThread()) {
         <button class="btn-secundary" (click)="openThread(message().id)">
           <mat-icon class="material-symbols-outlined"> comment </mat-icon>
         </button>
@@ -70,12 +70,12 @@
             <span class="font-size-14">Letzte Antwort {{ $any(message()).thread[$any(message()).thread.length - 1]?.time }} Uhr</span>
           </div>
         }
-        @if (channelType !== "direct" && isChannelMessage()) {
+        @if (channelType() !== "direct" && isChannelMessage()) {
           <app-message-reactions
             [message]="$any(message())"
-            [currentChannelId]="currentChannelId"
-            [parentMessageId]="parentMessageId"
-            [isThread]="isThread"
+            [currentChannelId]="currentChannelId()"
+            [parentMessageId]="parentMessageId()"
+            [isThread]="isThread()"
           ></app-message-reactions>
         }
       </footer>

--- a/src/app/features/app_chat/components/message/message-template.component.html
+++ b/src/app/features/app_chat/components/message/message-template.component.html
@@ -1,25 +1,23 @@
 <div
-  (mouseleave)="reactionMenuOpen = false; reactionMenuOpenInFooter = false; menuOpen = false"
+  (mouseleave)="reactionMenuOpen = false; menuOpen = false"
   class="message"
   [ngClass]="{
-    reverse: message.name == this.authService.currentUser()?.displayName,
+    reverse: isOwnMessage(),
   }"
 >
   @if (!isEditing && channelType !== "direct") {
     <div class="reaction-bar">
       <button
         class="btn-secundary"
-        [ngClass]="{ 'bg-purple': this.hasReacted(preSelectedEmojis['checkMark'], reactions()) }"
-        (click)="addReaction(message, preSelectedEmojis['checkMark'])"
+        [ngClass]="{ 'bg-purple': hasReacted(preSelectedEmojis['checkMark']) }"
+        (click)="toggleReaction(preSelectedEmojis['checkMark'])"
       >
         {{ preSelectedEmojis["checkMark"] }}
       </button>
       <button
         class="btn-secundary"
-        [ngClass]="{
-          'bg-purple': this.hasReacted(preSelectedEmojis['thumbsUp'], reactions()),
-        }"
-        (click)="addReaction(message, preSelectedEmojis['thumbsUp'])"
+        [ngClass]="{ 'bg-purple': hasReacted(preSelectedEmojis['thumbsUp']) }"
+        (click)="toggleReaction(preSelectedEmojis['thumbsUp'])"
       >
         {{ preSelectedEmojis["thumbsUp"] }}
       </button>
@@ -32,30 +30,22 @@
         </button>
       }
 
-      <button
-        *ngIf="message.name == authService.currentUser()?.displayName"
-        class="hover-to-dark-purple"
-        (click)="this.menuOpen = !this.menuOpen"
-      >
-        <mat-icon>more_vert</mat-icon>
-      </button>
-      @if (menuOpen && message.name == authService.currentUser()?.displayName) {
+      @if (isOwnMessage()) {
+        <button class="hover-to-dark-purple" (click)="this.menuOpen = !this.menuOpen">
+          <mat-icon>more_vert</mat-icon>
+        </button>
+      }
+      @if (menuOpen && isOwnMessage()) {
         <div class="menu">
           <button (click)="editMessage(message())">Nachricht bearbeiten</button>
         </div>
       }
-      @if (reactionMenuOpen) {
+      @if (reactionMenuOpen && isChannelMessage()) {
         <div class="reaction-menu">
           @for (emoji of preSelectedEmojiList; track $index) {
-            @if (isChannelMessage()) {
-              <button
-                class="btn-secundary circle"
-                [ngClass]="{ 'bg-purple': hasReacted(emoji, reactions()) }"
-                (click)="addReaction(message(), emoji)"
-              >
-                {{ emoji }}
-              </button>
-            }
+            <button class="btn-secundary circle" [ngClass]="{ 'bg-purple': hasReacted(emoji) }" (click)="toggleReaction(emoji)">
+              {{ emoji }}
+            </button>
           }
         </div>
       }
@@ -80,81 +70,13 @@
             <span class="font-size-14">Letzte Antwort {{ $any(message()).thread[$any(message()).thread.length - 1]?.time }} Uhr</span>
           </div>
         }
-        @if (channelType !== "direct") {
-          <div class="emoji-container">
-            @for (
-              emoji of showAllReactions
-                ? uniqueEmojis($any(message()).reaction)
-                : (uniqueEmojis($any(message()).reaction) | slice: 0 : (navigationService.isMobile() ? 2 : 20));
-              track $index
-            ) {
-              <div
-                (click)="addReaction($any(message()), emoji.emoji)"
-                [ngClass]="{ 'bg-purple': this.hasReacted(emoji.emoji, reactions()) }"
-                class="emoji-box"
-              >
-                <span>{{ emoji.emoji }}</span>
-                <span>{{ countEmoji(emoji, $any(message()).reaction) }}</span>
-                <div class="reaction-from-dialog">
-                  <span>{{ emoji.emoji }}</span>
-                  @for (name of getReactionNamesForEmoji(emoji.emoji, reactions()); track $index) {
-                    <h3 class="font-weight-700">{{ name }}</h3>
-                  }
-                  @if (getReactionNamesForEmoji(emoji.emoji, reactions()).length > 1) {
-                    <span>haben</span>
-                  }
-                  @if (
-                    getReactionNamesForEmoji(emoji.emoji, reactions()).length === 1 &&
-                    getReactionNamesForEmoji(emoji.emoji, reactions())[0] === "Du"
-                  ) {
-                    <span>hast</span>
-                  } @else if (
-                    getReactionNamesForEmoji(emoji.emoji, reactions()).length === 1 &&
-                    getReactionNamesForEmoji(emoji.emoji, reactions())[0] !== "Du"
-                  ) {
-                    <span>hat</span>
-                  }
-                  <span> reagiert</span>
-                </div>
-              </div>
-            }
-
-            <button
-              class="emoji-box"
-              *ngIf="countUniqueEmojis(reactions()) > (navigationService.isMobile() ? 2 : 20) && !showAllReactions"
-              (click)="showAllReactions = true"
-            >
-              {{ countUniqueEmojis(reactions()) - (navigationService.isMobile() ? 2 : 20) }} weitere
-            </button>
-            <button
-              class="emoji-box"
-              *ngIf="reactions().length > (navigationService.isMobile() ? 2 : 20) && showAllReactions"
-              (click)="showAllReactions = false"
-            >
-              Weniger anzeigen
-            </button>
-            <button
-              *ngIf="reactions().length > 0"
-              (click)="this.reactionMenuOpenInFooter = !this.reactionMenuOpenInFooter"
-              class="hover-to-dark-purple"
-            >
-              <mat-icon class="material-symbols-outlined"> add_reaction </mat-icon>
-            </button>
-
-            @if (reactionMenuOpenInFooter) {
-              <div class="reaction-menu">
-                @for (emoji of preSelectedEmojiList; track $index) {
-                  <button
-                    class="btn-secundary circle"
-                    [ngClass]="{ 'bg-purple': this.hasReacted(emoji, reactions()) }"
-                    (click)="addReaction(message, emoji)"
-                  >
-                    {{ emoji }}
-                  </button>
-                }
-              </div>
-            }
-          </div>
+        @if (channelType !== "direct" && isChannelMessage()) {
+          <app-message-reactions
+            [message]="$any(message())"
+            [currentChannelId]="currentChannelId"
+            [parentMessageId]="parentMessageId"
+            [isThread]="isThread"
+          ></app-message-reactions>
         }
       </footer>
     </section>
@@ -166,7 +88,7 @@
       <div class="action-container">
         <div class="d-flex gap-32">
           <button class="btn btn-outline" (click)="cancel()">Abbrechen</button>
-          <button class="btn btn-primary" (click)="updateMessage(message)">Speichern</button>
+          <button class="btn btn-primary" (click)="updateMessage(message())">Speichern</button>
         </div>
       </div>
     </div>

--- a/src/app/features/app_chat/components/message/message-template.component.ts
+++ b/src/app/features/app_chat/components/message/message-template.component.ts
@@ -7,21 +7,23 @@ import { FormsModule } from '@angular/forms';
 
 import { MatDialog } from '@angular/material/dialog';
 import { NavigationService } from '../../../../shared/services/navigation/navigation.service';
-import emojiData from 'unicode-emoji-json';
 
 import { LinkifyPipe } from '../../../pipes/linkify.pipe';
-import { UserStore } from '../../../../shared/services/user/user-store';
-import { MentionService } from '../../../../shared/services/mention/mention.service';
 
 import { DialogReciverComponent } from '../../../dialogs/dialog-reciver/dialog-reciver.component';
 import { ChannelMessage } from '../../models/channel-message/channel-message';
 import { AuthService } from '../../../app_auth/services/auth/auth.service';
 import { DirectMessage } from '../../models/direct-message/direct-message';
 import { User } from '../../../app_auth/models/user/user';
+import { UserStore } from '../../../../shared/services/user/user-store';
+import { MentionService } from '../../../../shared/services/mention/mention.service';
+import { ReactionContext, ReactionsService } from '../../services/reactions/reactions.service';
+import { MessageReactionsComponent } from './message-reactions/message-reactions.component';
+import { PRESELECTED_EMOJIS } from '../../../../shared/constants';
 
 @Component({
   selector: 'app-message-template',
-  imports: [CommonModule, MatIconModule, FormsModule, LinkifyPipe],
+  imports: [CommonModule, MatIconModule, FormsModule, LinkifyPipe, MessageReactionsComponent],
   templateUrl: './message-template.component.html',
   styleUrl: './message-template.component.scss',
 })
@@ -32,26 +34,14 @@ export class MessageTemplateComponent {
   public navigationService: NavigationService = inject(NavigationService);
   private userStore: UserStore = inject(UserStore);
   private mentionService: MentionService = inject(MentionService);
+  public reactionsService: ReactionsService = inject(ReactionsService);
+
   menuOpen: boolean = false;
   reactionMenuOpen: boolean = false;
-  reactionMenuOpenInFooter: boolean = false;
   isEditing: boolean = false;
-  showAllReactions: boolean = false;
   inputEdit: string = '';
-  emojis: string[] = [
-    'emoji _nerd face_',
-    'emoji _person raising both hands in celebration_',
-    'emoji _rocket_',
-    'emoji _white heavy check mark_',
-  ];
-  public emojiDataBase: any;
-  public preSelectedEmojis: Record<string, string> = {
-    thumbsUp: '\u{1F44D}',
-    checkMark: '\u{2705}',
-    rocket: '\u{1F680}',
-    nerd: '\u{1F913}',
-  };
-  public preSelectedEmojiList = Object.values(this.preSelectedEmojis);
+  public readonly preSelectedEmojis = PRESELECTED_EMOJIS;
+  public readonly preSelectedEmojiList = Object.values(PRESELECTED_EMOJIS);
 
   message = input.required<ChannelMessage | DirectMessage>();
   @Input() currentChannelId: string = '';
@@ -61,23 +51,39 @@ export class MessageTemplateComponent {
 
   isChannelMessage = computed(() => this.message() instanceof ChannelMessage);
 
+  isOwnMessage = computed(() => this.message().name === this.authService.currentUser()?.displayName);
+
   reactions = computed(() => {
     const msg = this.message();
     return msg instanceof ChannelMessage ? msg.reaction : [];
   });
 
+  private reactionContext(): ReactionContext {
+    return {
+      channelId: this.currentChannelId,
+      parentMessageId: this.parentMessageId,
+      isThread: this.isThread,
+    };
+  }
+
   /**
-   * Initializes the component by setting the current user ID
-   * and loading the emoji database.
+   * Toggles an emoji reaction on this message (hover reaction bar).
    */
-  constructor() {
-    this.emojiDataBase = emojiData;
+  public toggleReaction(emoji: string) {
+    const msg = this.message();
+    if (msg instanceof ChannelMessage) {
+      this.reactionsService.toggleReaction(msg, emoji, this.reactionContext());
+      this.reactionMenuOpen = false;
+    }
+  }
+
+  public hasReacted(emoji: string): boolean {
+    return this.reactionsService.hasReacted(emoji, this.reactions());
   }
 
   /**
    * Enables editing mode for a specific message.
    * @param message - The message to edit
-   * @param index - Index of the message in the message list
    */
   public editMessage(message: ChannelMessage | DirectMessage) {
     this.menuOpen = false;
@@ -85,7 +91,7 @@ export class MessageTemplateComponent {
     this.inputEdit = message.message;
   }
 
-  public async updateMessage(message: any) {
+  public async updateMessage(message: ChannelMessage | DirectMessage) {
     this.isThread ? this.updateThreadMessage(message) : this.updateChannelMessage(message);
   }
 
@@ -93,7 +99,7 @@ export class MessageTemplateComponent {
    * Updates the message after editing.
    * @param message - The message to update.
    */
-  private updateThreadMessage(message: any) {
+  private updateThreadMessage(message: ChannelMessage | DirectMessage) {
     let messageRef = this.fireService.getMessageThreadRef(this.currentChannelId, this.parentMessageId, message.id);
     if (messageRef) {
       this.isEditing = false;
@@ -108,8 +114,7 @@ export class MessageTemplateComponent {
    * Updates the content of an edited message.
    * @param message - The message to update
    */
-
-  private updateChannelMessage(message: any) {
+  private updateChannelMessage(message: ChannelMessage | DirectMessage) {
     let messageRef = this.fireService.getMessageRef(this.currentChannelId, message.id);
     if (messageRef) {
       this.isEditing = false;
@@ -121,114 +126,9 @@ export class MessageTemplateComponent {
   /**
    * Opens the thread view for a specific message.
    * @param messageId - ID of the message to open
-   * @param $event - The click event
    */
   public openThread(messageId: string) {
     this.navigationService.goToThread(messageId, this.currentChannelId);
-  }
-
-  /**
-   * Adds a reaction to a message or removes it if already reacted.
-   * @param message - The message to react to
-   * @param emoji - The emoji reaction
-   */
-  public addReaction(message: any, emoji: string) {
-    let messageRef;
-    this.isThread
-      ? (messageRef = this.fireService.getMessageThreadRef(this.currentChannelId, this.parentMessageId, message.id))
-      : (messageRef = this.fireService.getMessageRef(this.currentChannelId, message.id));
-
-    let newReaction = { emoji: emoji, from: this.authService.currentUser()?.id || 'n/a' };
-    if (!this.hasReacted(newReaction.emoji, message.reaction)) {
-      message.reaction.push(newReaction);
-      if (messageRef) {
-        this.fireService.updateReaction(messageRef, message.reaction);
-        this.reactionMenuOpen = false;
-      }
-    } else this.removeReaction(message, emoji);
-  }
-
-  /**
-   * Checks if the user has already reacted with a specific emoji.
-   * @param emoji - The emoji to check
-   * @param reactions - The list of reactions
-   * @returns True if the user has reacted, otherwise false
-   */
-  public hasReacted(emoji: any, reactions: any[]): boolean | undefined {
-    if (this.channelType !== 'direct')
-      return reactions.some((reaction) => reaction.from === this.authService.currentUser()?.id && reaction.emoji === emoji);
-    return;
-  }
-
-  /**
-   * Removes a specific emoji reaction from a message.
-   * @param message - The message to update
-   * @param emoji - The emoji to remove
-   */
-  public removeReaction(message: any, emoji: string): any {
-    let messageRef;
-    this.isThread
-      ? (messageRef = this.fireService.getMessageThreadRef(this.currentChannelId, this.parentMessageId, message.id))
-      : (messageRef = this.fireService.getMessageRef(this.currentChannelId, message.id));
-
-    let reactionIndex = message.reaction.findIndex((r: any) => r.from === this.authService.currentUser()?.id && r.emoji === emoji);
-    if (reactionIndex >= 0) {
-      message.reaction.splice(reactionIndex, 1);
-      if (messageRef) {
-        this.fireService.updateReaction(messageRef, message.reaction);
-      }
-    }
-  }
-
-  /**
-   * Filters unique emojis from the reactions array.
-   * @param reactions - Array of emoji reactions
-   * @returns Filtered array with unique emojis
-   */
-  public uniqueEmojis(reactions: any[]): any[] {
-    return reactions.filter((reaction, index) => index === reactions.findIndex((r) => r.emoji === reaction.emoji));
-  }
-
-  /**
-   * Counts how many times an emoji was used in a reaction list.
-   * @param emoji - The emoji to count
-   * @param reactions - The array of reactions
-   * @returns Number of times the emoji was used
-   */
-  public countEmoji(emoji: any, reactions: any[]) {
-    return reactions.filter((e) => e.emoji === emoji.emoji).length;
-  }
-
-  /**
-   * Counts how many unique emojis exist in a list.
-   * @param iterable - The array to check
-   * @returns Count of unique emojis
-   */
-  public countUniqueEmojis(iterable: any[]): number {
-    return new Set(iterable.map((e) => e.emoji)).size;
-  }
-
-  /**
-   * Returns the names of users who have reacted to a specific emoji.
-   * @param targetEmoji - The emoji to check reactions for
-   * @param reactions - The list of reactions to check
-   * @returns A list of user names who have reacted with the target emoji
-   */
-  public getReactionNamesForEmoji(targetEmoji: string, reactions: any[]): string[] | any {
-    let allUsers = this.fireService.allUsers();
-    let reactionsWithEmoji = reactions.filter((reaction: any) => reaction.emoji === targetEmoji);
-    let userIds = reactionsWithEmoji.map((reaction: any) => reaction.from);
-    let hasCurrentUserReacted = userIds.includes(this.authService.currentUser()?.id);
-
-    let otherUsers = allUsers
-      .filter((user: any) => userIds.includes(user.id) && user.id !== this.authService.currentUser()?.id)
-      .map((user: any) => user.displayName);
-
-    if (hasCurrentUserReacted) {
-      if (otherUsers.length === 0) return ['Du'];
-      else otherUsers.push('und du');
-    }
-    return otherUsers.length > 0 ? otherUsers : [];
   }
 
   /**
@@ -252,11 +152,7 @@ export class MessageTemplateComponent {
   }
 
   /**
-   * Retrieves a user document from Firestore by matching the full name.
-   * Queries the 'users' collection where 'displayName' equals the provided message name.
-   *
-   * @returns A promise that resolves to the user data object including the document ID,
-   *          or null if no matching user is found.
+   * Resolves the message author's user document by display name.
    */
   private async _getReceiverByName(): Promise<User | null> {
     const searchName = this.message().name;

--- a/src/app/features/app_chat/components/message/message-template.component.ts
+++ b/src/app/features/app_chat/components/message/message-template.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, computed, inject, input, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
 import { FireServiceService } from '../../../../shared/services/firebase/fire-service.service';
 import { MatIconModule } from '@angular/material/icon';
 
@@ -26,6 +26,7 @@ import { PRESELECTED_EMOJIS } from '../../../../shared/constants';
   imports: [CommonModule, MatIconModule, FormsModule, LinkifyPipe, MessageReactionsComponent],
   templateUrl: './message-template.component.html',
   styleUrl: './message-template.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MessageTemplateComponent {
   private fireService: FireServiceService = inject(FireServiceService);
@@ -44,10 +45,10 @@ export class MessageTemplateComponent {
   public readonly preSelectedEmojiList = Object.values(PRESELECTED_EMOJIS);
 
   message = input.required<ChannelMessage | DirectMessage>();
-  @Input() currentChannelId: string = '';
-  @Input() parentMessageId: string = '';
-  @Input() isThread: boolean = false;
-  @Input() channelType: 'direct' | 'channel' | 'thread' | null = null;
+  currentChannelId = input<string>('');
+  parentMessageId = input<string>('');
+  isThread = input<boolean>(false);
+  channelType = input<'direct' | 'channel' | 'thread' | null>(null);
 
   isChannelMessage = computed(() => this.message() instanceof ChannelMessage);
 
@@ -60,9 +61,9 @@ export class MessageTemplateComponent {
 
   private reactionContext(): ReactionContext {
     return {
-      channelId: this.currentChannelId,
-      parentMessageId: this.parentMessageId,
-      isThread: this.isThread,
+      channelId: this.currentChannelId(),
+      parentMessageId: this.parentMessageId(),
+      isThread: this.isThread(),
     };
   }
 
@@ -92,7 +93,7 @@ export class MessageTemplateComponent {
   }
 
   public async updateMessage(message: ChannelMessage | DirectMessage) {
-    this.isThread ? this.updateThreadMessage(message) : this.updateChannelMessage(message);
+    this.isThread() ? this.updateThreadMessage(message) : this.updateChannelMessage(message);
   }
 
   /**
@@ -100,7 +101,7 @@ export class MessageTemplateComponent {
    * @param message - The message to update.
    */
   private updateThreadMessage(message: ChannelMessage | DirectMessage) {
-    let messageRef = this.fireService.getMessageThreadRef(this.currentChannelId, this.parentMessageId, message.id);
+    let messageRef = this.fireService.getMessageThreadRef(this.currentChannelId(), this.parentMessageId(), message.id);
     if (messageRef) {
       this.isEditing = false;
       try {
@@ -115,7 +116,7 @@ export class MessageTemplateComponent {
    * @param message - The message to update
    */
   private updateChannelMessage(message: ChannelMessage | DirectMessage) {
-    let messageRef = this.fireService.getMessageRef(this.currentChannelId, message.id);
+    let messageRef = this.fireService.getMessageRef(this.currentChannelId(), message.id);
     if (messageRef) {
       this.isEditing = false;
       this.fireService.updateMessage(messageRef, this.inputEdit);
@@ -128,7 +129,7 @@ export class MessageTemplateComponent {
    * @param messageId - ID of the message to open
    */
   public openThread(messageId: string) {
-    this.navigationService.goToThread(messageId, this.currentChannelId);
+    this.navigationService.goToThread(messageId, this.currentChannelId());
   }
 
   /**

--- a/src/app/features/app_chat/models/channel-message/channel-message.ts
+++ b/src/app/features/app_chat/models/channel-message/channel-message.ts
@@ -1,8 +1,13 @@
 import { BaseMessage } from '../base-message/base-message';
 
+export interface Reaction {
+  emoji: string;
+  from: string;
+}
+
 export class ChannelMessage extends BaseMessage {
-  reaction: string[];
-  thread: string[];
+  reaction: Reaction[];
+  thread: any[];
 
   constructor(obj?: any) {
     super(obj);

--- a/src/app/features/app_chat/services/messages/messages.service.ts
+++ b/src/app/features/app_chat/services/messages/messages.service.ts
@@ -12,7 +12,7 @@ export class MessagesService {
   private fireService = inject(FireServiceService);
   private readonly authService = inject(AuthService);
 
-  public messages = signal<ChannelMessage[] | DirectMessage[]>([]);
+  public messages = signal<(ChannelMessage | DirectMessage)[]>([]);
   public threadMessages = signal<(ChannelMessage | DirectMessage)[]>([]);
 
   public subToMessages(channelId: string | null) {
@@ -76,11 +76,11 @@ export class MessagesService {
    * @param snap - The Firestore snapshot containing the messages.
    * @returns An array of processed message objects.
    */
-  public processData(snap: QuerySnapshot<any>): any[] {
-    return snap.docs.map((doc: any) => {
-      const data = doc.data();
+  public processData(snap: QuerySnapshot): (ChannelMessage | DirectMessage)[] {
+    return snap.docs.map((doc) => {
+      const data = doc.data() as ChannelMessage | DirectMessage;
       const id = doc.id;
-      return this.isChannelMessage(data) ? new ChannelMessage({ id, ...data }) : new DirectMessage({ id, ...data });
+      return this.isChannelMessage(data) ? new ChannelMessage({ ...data, id }) : new DirectMessage({ ...data, id });
     });
   }
 

--- a/src/app/features/app_chat/services/reactions/reactions.service.ts
+++ b/src/app/features/app_chat/services/reactions/reactions.service.ts
@@ -1,0 +1,105 @@
+import { inject, Injectable } from '@angular/core';
+import { FireServiceService } from '../../../../shared/services/firebase/fire-service.service';
+import { UserStore } from '../../../../shared/services/user/user-store';
+import { ChannelMessage, Reaction } from '../../models/channel-message/channel-message';
+
+export interface ReactionContext {
+  channelId: string;
+  parentMessageId?: string;
+  isThread?: boolean;
+}
+
+/**
+ * Owns all emoji-reaction logic for channel and thread messages
+ * (shared by the hover reaction bar and the message footer).
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class ReactionsService {
+  private readonly fireService = inject(FireServiceService);
+  private readonly userStore = inject(UserStore);
+
+  private currentUserId(): string {
+    return this.userStore.currentUser()?.id || 'n/a';
+  }
+
+  private getMessageRef(messageId: string, context: ReactionContext) {
+    return context.isThread && context.parentMessageId
+      ? this.fireService.getMessageThreadRef(context.channelId, context.parentMessageId, messageId)
+      : this.fireService.getMessageRef(context.channelId, messageId);
+  }
+
+  /**
+   * Adds the emoji reaction, or removes it if the user already reacted with it.
+   */
+  public toggleReaction(message: ChannelMessage, emoji: string, context: ReactionContext): void {
+    if (this.hasReacted(emoji, message.reaction)) {
+      this.removeReaction(message, emoji, context);
+      return;
+    }
+
+    message.reaction.push({ emoji: emoji, from: this.currentUserId() });
+    const messageRef = this.getMessageRef(message.id, context);
+    if (messageRef) this.fireService.updateReaction(messageRef, message.reaction);
+  }
+
+  /**
+   * Removes the user's reaction with the given emoji from the message.
+   */
+  public removeReaction(message: ChannelMessage, emoji: string, context: ReactionContext): void {
+    const reactionIndex = message.reaction.findIndex((r) => r.from === this.currentUserId() && r.emoji === emoji);
+    if (reactionIndex < 0) return;
+
+    message.reaction.splice(reactionIndex, 1);
+    const messageRef = this.getMessageRef(message.id, context);
+    if (messageRef) this.fireService.updateReaction(messageRef, message.reaction);
+  }
+
+  /**
+   * Whether the current user already reacted with this emoji.
+   */
+  public hasReacted(emoji: string, reactions: Reaction[]): boolean {
+    return reactions.some((reaction) => reaction.from === this.currentUserId() && reaction.emoji === emoji);
+  }
+
+  /**
+   * Filters unique emojis from the reactions array.
+   */
+  public uniqueEmojis(reactions: Reaction[]): Reaction[] {
+    return reactions.filter((reaction, index) => index === reactions.findIndex((r) => r.emoji === reaction.emoji));
+  }
+
+  /**
+   * Counts how many times an emoji was used in a reaction list.
+   */
+  public countEmoji(emoji: string, reactions: Reaction[]): number {
+    return reactions.filter((r) => r.emoji === emoji).length;
+  }
+
+  /**
+   * Counts how many unique emojis exist in a list.
+   */
+  public countUniqueEmojis(reactions: Reaction[]): number {
+    return new Set(reactions.map((r) => r.emoji)).size;
+  }
+
+  /**
+   * Returns the display names of users who reacted with the emoji;
+   * the current user is rendered as 'Du' / 'und du'.
+   */
+  public getReactionNamesForEmoji(targetEmoji: string, reactions: Reaction[]): string[] {
+    const allUsers = this.fireService.allUsers();
+    const userIds = reactions.filter((r) => r.emoji === targetEmoji).map((r) => r.from);
+    const currentUserId = this.userStore.currentUser()?.id;
+    const hasCurrentUserReacted = userIds.includes(currentUserId || '');
+
+    const otherUsers = allUsers.filter((user) => userIds.includes(user.id) && user.id !== currentUserId).map((user) => user.displayName);
+
+    if (hasCurrentUserReacted) {
+      if (otherUsers.length === 0) return ['Du'];
+      otherUsers.push('und du');
+    }
+    return otherUsers;
+  }
+}

--- a/src/app/shared/components/avatar-picker/avatar-picker.component.ts
+++ b/src/app/shared/components/avatar-picker/avatar-picker.component.ts
@@ -1,4 +1,4 @@
-import { Component, model } from '@angular/core';
+import { ChangeDetectionStrategy, Component, model } from '@angular/core';
 import { AVATAR_IMAGES } from '../../constants';
 
 /**
@@ -9,6 +9,7 @@ import { AVATAR_IMAGES } from '../../constants';
   selector: 'app-avatar-picker',
   templateUrl: './avatar-picker.component.html',
   styleUrl: './avatar-picker.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AvatarPickerComponent {
   public readonly avatars = AVATAR_IMAGES;

--- a/src/app/shared/components/profile-status/profile-status.component.ts
+++ b/src/app/shared/components/profile-status/profile-status.component.ts
@@ -1,11 +1,12 @@
 import { CommonModule } from '@angular/common';
-import { Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 
 @Component({
   selector: 'app-profile-status',
   imports: [CommonModule],
   templateUrl: './profile-status.component.html',
   styleUrl: './profile-status.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ProfileStatusComponent {
   photoUrl = input.required<string>();

--- a/src/app/shared/constants.ts
+++ b/src/app/shared/constants.ts
@@ -6,6 +6,13 @@ export const GUEST_EMAIL = 'gast@portfolio.de';
 
 export const DEFAULT_AVATAR = 'img/avatars/avatar_default.png';
 
+export const PRESELECTED_EMOJIS: Record<string, string> = {
+  thumbsUp: '\u{1F44D}',
+  checkMark: '\u{2705}',
+  rocket: '\u{1F680}',
+  nerd: '\u{1F913}',
+};
+
 export const AVATAR_IMAGES = [
   'img/avatars/avatar_1.png',
   'img/avatars/avatar_2.png',

--- a/src/app/shared/services/firebase/fire-service.service.ts
+++ b/src/app/shared/services/firebase/fire-service.service.ts
@@ -14,7 +14,7 @@ import {
   updateDoc,
   where,
 } from '@angular/fire/firestore';
-import { ChannelMessage } from '../../../features/app_chat/models/channel-message/channel-message';
+import { ChannelMessage, Reaction } from '../../../features/app_chat/models/channel-message/channel-message';
 import { User } from '../../../features/app_auth/models/user/user';
 import { Channel } from '../../../features/app_channel/models/channel/channel';
 import { DEFAULT_CHANNEL_ID, GUEST_EMAIL } from '../../constants';
@@ -27,7 +27,7 @@ export class FireServiceService {
   private firestore: Firestore = inject(Firestore);
   private userStore = inject(UserStore);
   public allUsers = signal<User[]>([]);
-  private _allChannels = signal<any[]>([]);
+  private _allChannels = signal<Channel[]>([]);
   private unsubAllUsers?: () => void;
   private unsubChannels?: () => void;
 
@@ -82,10 +82,13 @@ export class FireServiceService {
     const channelRef = collection(this.firestore, 'channels');
 
     this.unsubChannels = onSnapshot(channelRef, (snapshot) => {
-      const data = snapshot.docs.map((doc) => ({
-        id: doc.id,
-        ...doc.data(),
-      }));
+      const data = snapshot.docs.map(
+        (doc) =>
+          ({
+            id: doc.id,
+            ...doc.data(),
+          }) as Channel,
+      );
       this._allChannels.set(data);
     });
   }
@@ -158,7 +161,7 @@ export class FireServiceService {
    * @param value The updated message value.
    * @returns A promise that resolves when the update is complete.
    */
-  updateMessage(ref: DocumentReference, value: any) {
+  updateMessage(ref: DocumentReference, value: string) {
     return ref ? updateDoc(ref, { message: value }) : null;
   }
 
@@ -169,7 +172,7 @@ export class FireServiceService {
    * @param value The updated reaction value.
    * @returns A promise that resolves when the update is complete.
    */
-  updateReaction(ref: DocumentReference, value: any) {
+  updateReaction(ref: DocumentReference, value: Reaction[]) {
     return ref ? updateDoc(ref, { reaction: value }) : null;
   }
 


### PR DESCRIPTION
Setzt **Phase 7 der Refactoring-Roadmap** um (basiert auf main, #18 ist bereits gemerged).

### Änderungen (je 1 Commit)
- **message-template zerlegt**: Reaktions-Logik lebt in einem `ReactionsService` (typisiert über neues `Reaction`-Interface — das Model deklarierte fälschlich `reaction: string[]`); die Footer-Reaktions-UI ist eine eigene `MessageReactionsComponent` mit computed-Signals. Parent schrumpft von 347 auf ~190 Zeilen.
  - ⚠️ Fixt dabei **latente Bugs aus der `input()`-Migration**: Templates verglichen/übergaben die Signal-Funktion selbst (`message.name`, `addReaction(message, …)`, `updateMessage(message)`) — eigene-Nachricht-Erkennung (reverse-Styling, Edit-Menü), Hover-Bar-Reaktionen und Edit-Speichern waren dadurch defekt
- **Typisierung**: `FireService._allChannels: Channel[]`, `updateMessage(string)`/`updateReaction(Reaction[])`, `processData` liefert typisierte Message-Instanzen, `messages`-Signal als Union-Array
- **Signal-Inputs & OnPush**: message-template auf `input()`-Signals; message-reactions, divider-template, profile-status, avatar-picker mit `ChangeDetectionStrategy.OnPush`; `showAllReactions`/`reactionMenuOpen` als Signale (wurden in einem `computed` gelesen)

### Verifikation
`ng build` grün nach jedem Commit. Smoke-Test mit zweitem Browserfenster: Reaktion hinzufügen/entfernen (Hover-Bar UND Footer), Hover zeigt Namen, „x weitere"-Collapse, Nachricht bearbeiten, eigene Nachricht rechtsbündig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)